### PR TITLE
NBT Locking Support

### DIFF
--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -160,8 +160,10 @@ public class LevelLockHandler {
             ItemStack stack = player.getHeldItemMainhand();
 
             if (ConfigHandler.enforceFakePlayers) {
-                if (isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
+                if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                     event.setCanceled(true);
+                    if (!isFake(player))
+                        tellPlayer(player, stack, MessageLockedItem.MSG_ITEM_LOCKED);
                 }
             } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
                 tellPlayer(player, stack, MessageLockedItem.MSG_ITEM_LOCKED);
@@ -186,10 +188,12 @@ public class LevelLockHandler {
                 stack = block.getItem(event.getWorld(), event.getPos(), state);
 
             if (ConfigHandler.enforceFakePlayers) {
-                if (isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
+                if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                     event.setCanceled(true);
+                    if (!isFake(player))
+                        tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
                 }
-            } else if (!player.isCreative() && !canPlayerUseItem(player, stack) && !isFake(player)) {
+            } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
                 tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
                 event.setCanceled(true);
             }
@@ -215,9 +219,11 @@ public class LevelLockHandler {
         if (stack.isEmpty())
             stack = block.getItem(event.getWorld(), event.getPos(), state);
         if (ConfigHandler.enforceFakePlayers) {
-            if (isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
+            if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                 event.setUseBlock(Result.DENY);
                 event.setUseItem(player.isSneaking() ? Result.DEFAULT : Result.DENY);
+                if (!isFake(player))
+                    tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_USE_LOCKED);
             }
         } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
             tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_USE_LOCKED);
@@ -235,8 +241,10 @@ public class LevelLockHandler {
         ItemStack stack = new ItemStack(block, 1, meta);
 
         if (ConfigHandler.enforceFakePlayers) {
-            if (isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
+            if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                 event.setCanceled(true);
+                if (!isFake(player))
+                    tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
             }
         } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
             tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
@@ -276,7 +284,7 @@ public class LevelLockHandler {
     }
 
     private static boolean isFake(Entity e) {
-        return ConfigHandler.enforceFakePlayers && e instanceof FakePlayer;
+        return e instanceof FakePlayer;
     }
 
     private static void enforce(PlayerInteractEvent event) {

--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -15,6 +15,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
@@ -31,16 +32,17 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.oredict.OreDictionary;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class LevelLockHandler {
 
-    public static final String[] DEFAULT_SKILL_LOCKS = new String[]{"minecraft:iron_shovel=reskillable:gathering|5", "minecraft:iron_axe=reskillable:gathering|5", "minecraft:iron_sword=reskillable:attack|5", "minecraft:iron_pickaxe=reskillable:mining|5", "minecraft:iron_hoe=reskillable:farming|5", "minecraft:iron_helmet=reskillable:defense|5", "minecraft:iron_chestplate=reskillable:defense|5", "minecraft:iron_leggings=reskillable:defense|5", "minecraft:iron_boots=reskillable:defense|5", "minecraft:golden_shovel=reskillable:gathering|5,reskillable:magic|5", "minecraft:golden_axe=reskillable:gathering|5,reskillable:magic|5", "minecraft:golden_sword=reskillable:attack|5,reskillable:magic|5", "minecraft:golden_pickaxe=reskillable:mining|5,reskillable:magic|5", "minecraft:golden_hoe=reskillable:farming|5,reskillable:magic|5", "minecraft:golden_helmet=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_chestplate=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_leggings=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_boots=reskillable:defense|5,reskillable:magic|5", "minecraft:diamond_shovel=reskillable:gathering|16", "minecraft:diamond_axe=reskillable:gathering|16", "minecraft:diamond_sword=reskillable:attack|16", "minecraft:diamond_pickaxe=reskillable:mining|16", "minecraft:diamond_hoe=reskillable:farming|16", "minecraft:diamond_helmet=reskillable:defense|16", "minecraft:diamond_chestplate=reskillable:defense|16", "minecraft:diamond_leggings=reskillable:defense|16", "minecraft:diamond_boots=reskillable:defense|16", "minecraft:shears=reskillable:farming|5,reskillable:gathering|5", "minecraft:fishing_rod=reskillable:gathering|8", "minecraft:shield=reskillable:defense|8", "minecraft:bow=reskillable:attack|8", "minecraft:ender_pearl=reskillable:magic|8", "minecraft:ender_eye=reskillable:magic|16,reskillable:building|8", "minecraft:elytra=reskillable:defense|16,reskillable:agility|24,reskillable:magic|16", "minecraft:lead=reskillable:farming|5", "minecraft:end_crystal=reskillable:building|24,reskillable:magic|32", "minecraft:iron_horse_armor=reskillable:defense|5,reskillable:agility|5", "minecraft:golden_horse_armor=reskillable:defense|5,reskillable:magic|5,reskillable:agility|5", "minecraft:diamond_horse_armor=reskillable:defense|16,reskillable:agility|16", "minecraft:fireworks=reskillable:agility|24", "minecraft:dye:15=reskillable:farming|12", "minecraft:saddle=reskillable:agility|12", "minecraft:redstone=reskillable:building|5", "minecraft:redstone_torch=reskillable:building|5", "minecraft:skull:1=reskillable:building|20,reskillable:attack|20,reskillable:defense|20"};
-    public static final Map<ItemStack, RequirementHolder> locks = new HashMap<>();
+    public static final String[] DEFAULT_SKILL_LOCKS = new String[]{"minecraft:iron_shovel:*=reskillable:gathering|5", "minecraft:iron_axe:*=reskillable:gathering|5", "minecraft:iron_sword:*=reskillable:attack|5", "minecraft:iron_pickaxe:*=reskillable:mining|5", "minecraft:iron_hoe:*=reskillable:farming|5", "minecraft:iron_helmet:*=reskillable:defense|5", "minecraft:iron_chestplate:*=reskillable:defense|5", "minecraft:iron_leggings:*=reskillable:defense|5", "minecraft:iron_boots:*=reskillable:defense|5", "minecraft:golden_shovel:*=reskillable:gathering|5,reskillable:magic|5", "minecraft:golden_axe:*=reskillable:gathering|5,reskillable:magic|5", "minecraft:golden_sword:*=reskillable:attack|5,reskillable:magic|5", "minecraft:golden_pickaxe:*=reskillable:mining|5,reskillable:magic|5", "minecraft:golden_hoe:*=reskillable:farming|5,reskillable:magic|5", "minecraft:golden_helmet:*=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_chestplate:*=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_leggings:*=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_boots:*=reskillable:defense|5,reskillable:magic|5", "minecraft:diamond_shovel:*=reskillable:gathering|16", "minecraft:diamond_axe:*=reskillable:gathering|16", "minecraft:diamond_sword:*=reskillable:attack|16", "minecraft:diamond_pickaxe:*=reskillable:mining|16", "minecraft:diamond_hoe:*=reskillable:farming|16", "minecraft:diamond_helmet:*=reskillable:defense|16", "minecraft:diamond_chestplate:*=reskillable:defense|16", "minecraft:diamond_leggings:*=reskillable:defense|16", "minecraft:diamond_boots:*=reskillable:defense|16", "minecraft:shears:*=reskillable:farming|5,reskillable:gathering|5", "minecraft:fishing_rod:*=reskillable:gathering|8", "minecraft:shield:*=reskillable:defense|8", "minecraft:bow:*=reskillable:attack|8", "minecraft:ender_pearl=reskillable:magic|8", "minecraft:ender_eye=reskillable:magic|16,reskillable:building|8", "minecraft:elytra:*=reskillable:defense|16,reskillable:agility|24,reskillable:magic|16", "minecraft:lead=reskillable:farming|5", "minecraft:end_crystal=reskillable:building|24,reskillable:magic|32", "minecraft:iron_horse_armor:*=reskillable:defense|5,reskillable:agility|5", "minecraft:golden_horse_armor:*=reskillable:defense|5,reskillable:magic|5,reskillable:agility|5", "minecraft:diamond_horse_armor:*=reskillable:defense|16,reskillable:agility|16", "minecraft:fireworks=reskillable:agility|24", "minecraft:dye:15=reskillable:farming|12", "minecraft:saddle=reskillable:agility|12", "minecraft:redstone=reskillable:building|5", "minecraft:redstone_torch=reskillable:building|5", "minecraft:skull:1=reskillable:building|20,reskillable:attack|20,reskillable:defense|20"};
     public static RequirementHolder EMPTY_LOCK = new RequirementHolder();
     public static Map<ItemStack, RequirementHolder> craftTweakerLocks = new HashMap<>();
+    private static final Map<ItemInfo, RequirementHolder> locks = new HashMap<>();
+    private static Map<ItemInfo, Set<NBTTagCompound>> nbtLockInfo = new HashMap<>();
     private static String[] configLocks;
 
     public static void loadFromConfig(String[] configValues) {
@@ -53,52 +55,91 @@ public class LevelLockHandler {
             for (String s : configLocks) {
                 String[] tokens = s.split("=");
                 if (tokens.length == 2) {
-                    RequirementHolder h = RequirementHolder.fromString(tokens[1]);
-                    locks.put(new ItemStack(Item.getByNameOrId(tokens[0].toLowerCase())), h);
+                    String itemName = tokens[0].toLowerCase();
+                    String[] itemParts = itemName.split(":");
+                    int metadata = 0;
+                    if (itemParts.length > 2) {
+                        String meta = itemParts[2];
+                        try {
+                            if (meta.equals("*"))
+                                metadata = OreDictionary.WILDCARD_VALUE;
+                            else
+                                metadata = Integer.parseInt(meta);
+                            itemName = itemParts[0] + ':' + itemParts[1];
+                        } catch (NumberFormatException ignored) {
+                            //Do nothing if the meta is not a valid number or wildcard (Maybe it somehow is part of the item name)
+                        }
+                    }
+                    Item item = Item.getByNameOrId(itemName);
+                    if (item != null)
+                        addToLock(new ItemStack(item, 1, metadata), RequirementHolder.fromString(tokens[1]));
                 }
             }
         }
-        locks.putAll(craftTweakerLocks);
+        craftTweakerLocks.forEach(LevelLockHandler::addToLock);
+    }
+
+    public static void addToLock(ItemStack stack, RequirementHolder holder) {
+        locks.put(new ItemInfo(stack.getItem(), stack.getMetadata(), stack.getTagCompound()), holder);
+        //Only bother mapping it if there is an NBT tag
+        if (stack.hasTagCompound())
+            //Store the NBT tag in a list for the specific item
+            nbtLockInfo.computeIfAbsent(new ItemInfo(stack.getItem(), stack.getMetadata()), k -> new HashSet<>()).add(stack.getTagCompound());
     }
 
     public static RequirementHolder getSkillLock(ItemStack stack) {
         if (stack == null || stack.isEmpty())
             return EMPTY_LOCK;
-        for (ItemStack itemStack : locks.keySet()) {
-            if (compareItem(itemStack, stack)) {
-                return locks.get(itemStack);
+
+        ItemInfo cleanStack = new ItemInfo(stack.getItem(), stack.getMetadata());
+        //There is no NBT information so matching is not needed. OR no specific NBT locks for this item stack so the NBT tags can be ignored
+        if (!stack.hasTagCompound() || !nbtLockInfo.containsKey(cleanStack))
+            return locks.getOrDefault(cleanStack, EMPTY_LOCK);
+
+        NBTTagCompound tag = stack.getTagCompound();
+        Set<NBTTagCompound> nbtLookup = nbtLockInfo.get(cleanStack);
+        ItemInfo bestStack = cleanStack; //Default to the clean variant of the stack
+        for (NBTTagCompound nbt : nbtLookup) {
+            if (tag.equals(nbt)) {
+                bestStack = new ItemInfo(stack.getItem(), stack.getMetadata(), nbt);
+                break;
             }
         }
-
-        return EMPTY_LOCK;
+        return locks.getOrDefault(bestStack, EMPTY_LOCK);
     }
 
-    private static boolean compareItem(ItemStack itemStack, ItemStack stack) {
-        if (itemStack.hasTagCompound() != stack.hasTagCompound()){
-            return false;
-        }
-        if (itemStack.hasTagCompound() && stack.hasTagCompound()) {
-            if (itemStack.getTagCompound().getKeySet().equals(stack.getTagCompound().getKeySet())){
-                for (String s : itemStack.getTagCompound().getKeySet()){
-                    if (!itemStack.getTagCompound().getTag(s).equals(stack.getTagCompound().getTag(s))){
-                        return false;
-                    }
-                }
-            }
-        }
-        if (itemStack.hasTagCompound() && !stack.hasTagCompound()){
-            return stack.getItem() == itemStack.getItem() && (itemStack.getMetadata() == 32767 || stack.getMetadata() == itemStack.getMetadata());
-        }
-        if (!itemStack.hasTagCompound() && stack.hasTagCompound()){
-            return stack.getItem() == itemStack.getItem() && (itemStack.getMetadata() == 32767 || stack.getMetadata() == itemStack.getMetadata());
-        }
-        if (!itemStack.hasTagCompound() && !stack.hasTagCompound()){
-            return stack.getItem() == itemStack.getItem() && (itemStack.getMetadata() == 32767 || stack.getMetadata() == itemStack.getMetadata());
+    private static class ItemInfo {
+        private int metadata;
+        private Item item;
+        private NBTTagCompound tag;
+
+        private ItemInfo(Item item, int metadata) {
+            this(item, metadata, null);
         }
 
-        // if the item has nbt, then meta shouldn't be accounted for?
-        return stack.getItem() == itemStack.getItem() && (itemStack.getMetadata() == 32767 || stack.getMetadata() == itemStack.getMetadata());
+        private ItemInfo(Item item, int metadata, NBTTagCompound tag) {
+            this.item = item;
+            this.metadata = metadata;
+            this.tag = tag;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this)
+                return true;
+            if (!(o instanceof ItemInfo))
+                return false;
+            ItemInfo other = (ItemInfo) o;
+            return item == other.item && tag == other.tag &&
+                    (metadata == OreDictionary.WILDCARD_VALUE || other.metadata == OreDictionary.WILDCARD_VALUE || metadata == other.metadata);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(item, tag);
+        }
     }
+
 
     public static boolean canPlayerUseItem(EntityPlayer player, ItemStack stack) {
         if (stack.isEmpty())

--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -172,8 +172,9 @@ public class LevelLockHandler {
             if (ConfigHandler.enforceFakePlayers) {
                 if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                     event.setCanceled(true);
-                    if (!isFake(player))
+                    if (!isFake(player)) {
                         tellPlayer(player, stack, MessageLockedItem.MSG_ITEM_LOCKED);
+                    }
                 }
             } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
                 tellPlayer(player, stack, MessageLockedItem.MSG_ITEM_LOCKED);
@@ -200,8 +201,9 @@ public class LevelLockHandler {
             if (ConfigHandler.enforceFakePlayers) {
                 if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                     event.setCanceled(true);
-                    if (!isFake(player))
+                    if (!isFake(player)) {
                         tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
+                    }
                 }
             } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
                 tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
@@ -232,8 +234,9 @@ public class LevelLockHandler {
             if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                 event.setUseBlock(Result.DENY);
                 event.setUseItem(player.isSneaking() ? Result.DEFAULT : Result.DENY);
-                if (!isFake(player))
+                if (!isFake(player)) {
                     tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_USE_LOCKED);
+                }
             }
         } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
             tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_USE_LOCKED);
@@ -253,8 +256,9 @@ public class LevelLockHandler {
         if (ConfigHandler.enforceFakePlayers) {
             if (!player.isCreative() && !canPlayerUseItem(player, stack)) {
                 event.setCanceled(true);
-                if (!isFake(player))
+                if (!isFake(player)) {
                     tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);
+                }
             }
         } else if (!isFake(player) && !player.isCreative() && !canPlayerUseItem(player, stack)) {
             tellPlayer(player, stack, MessageLockedItem.MSG_BLOCK_BREAK_LOCKED);

--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -15,7 +15,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
@@ -33,18 +32,15 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class LevelLockHandler {
 
     public static final String[] DEFAULT_SKILL_LOCKS = new String[]{"minecraft:iron_shovel=reskillable:gathering|5", "minecraft:iron_axe=reskillable:gathering|5", "minecraft:iron_sword=reskillable:attack|5", "minecraft:iron_pickaxe=reskillable:mining|5", "minecraft:iron_hoe=reskillable:farming|5", "minecraft:iron_helmet=reskillable:defense|5", "minecraft:iron_chestplate=reskillable:defense|5", "minecraft:iron_leggings=reskillable:defense|5", "minecraft:iron_boots=reskillable:defense|5", "minecraft:golden_shovel=reskillable:gathering|5,reskillable:magic|5", "minecraft:golden_axe=reskillable:gathering|5,reskillable:magic|5", "minecraft:golden_sword=reskillable:attack|5,reskillable:magic|5", "minecraft:golden_pickaxe=reskillable:mining|5,reskillable:magic|5", "minecraft:golden_hoe=reskillable:farming|5,reskillable:magic|5", "minecraft:golden_helmet=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_chestplate=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_leggings=reskillable:defense|5,reskillable:magic|5", "minecraft:golden_boots=reskillable:defense|5,reskillable:magic|5", "minecraft:diamond_shovel=reskillable:gathering|16", "minecraft:diamond_axe=reskillable:gathering|16", "minecraft:diamond_sword=reskillable:attack|16", "minecraft:diamond_pickaxe=reskillable:mining|16", "minecraft:diamond_hoe=reskillable:farming|16", "minecraft:diamond_helmet=reskillable:defense|16", "minecraft:diamond_chestplate=reskillable:defense|16", "minecraft:diamond_leggings=reskillable:defense|16", "minecraft:diamond_boots=reskillable:defense|16", "minecraft:shears=reskillable:farming|5,reskillable:gathering|5", "minecraft:fishing_rod=reskillable:gathering|8", "minecraft:shield=reskillable:defense|8", "minecraft:bow=reskillable:attack|8", "minecraft:ender_pearl=reskillable:magic|8", "minecraft:ender_eye=reskillable:magic|16,reskillable:building|8", "minecraft:elytra=reskillable:defense|16,reskillable:agility|24,reskillable:magic|16", "minecraft:lead=reskillable:farming|5", "minecraft:end_crystal=reskillable:building|24,reskillable:magic|32", "minecraft:iron_horse_armor=reskillable:defense|5,reskillable:agility|5", "minecraft:golden_horse_armor=reskillable:defense|5,reskillable:magic|5,reskillable:agility|5", "minecraft:diamond_horse_armor=reskillable:defense|16,reskillable:agility|16", "minecraft:fireworks=reskillable:agility|24", "minecraft:dye:15=reskillable:farming|12", "minecraft:saddle=reskillable:agility|12", "minecraft:redstone=reskillable:building|5", "minecraft:redstone_torch=reskillable:building|5", "minecraft:skull:1=reskillable:building|20,reskillable:attack|20,reskillable:defense|20"};
     public static final Map<ItemStack, RequirementHolder> locks = new HashMap<>();
     public static RequirementHolder EMPTY_LOCK = new RequirementHolder();
-    public static Map<Ingredient, RequirementHolder> craftTweakerLocks = new HashMap<>();
+    public static Map<ItemStack, RequirementHolder> craftTweakerLocks = new HashMap<>();
     private static String[] configLocks;
 
     public static void loadFromConfig(String[] configValues) {
@@ -62,6 +58,7 @@ public class LevelLockHandler {
                 }
             }
         }
+        locks.putAll(craftTweakerLocks);
     }
 
     public static RequirementHolder getSkillLock(ItemStack stack) {
@@ -72,12 +69,7 @@ public class LevelLockHandler {
                 return locks.get(itemStack);
             }
         }
-        for (Ingredient ingredient : craftTweakerLocks.keySet()){
-            ItemStack[] ingredientMatchingStacks = ingredient.getMatchingStacks();
-            for (int i = 0; i < ingredientMatchingStacks.length; i++){
-                compareItem(ingredientMatchingStacks[i], stack);
-            }
-        }
+
         return EMPTY_LOCK;
     }
 


### PR DESCRIPTION
Summary:
- I made the locks map private as to ensure it gets added to properly. addToLock(ItemStack, RequirementHolder) can be used to directly add to locks if need be. This was necessary to better support wildcard metadata values and make NBT for items a bit easier.
- The config once again supports metadata values for items (bone meal works by default now, I also added support for the config to accept wildcard metadata values '*').
- Default values for weapons, tools, and armor now have the wildcard metadata by default so that once a tool is used it keeps on requiring the correct skill level (stops people from using a tool once and then giving it to someone without the requirements).
- While testing the NBT locks I discovered that if enforcing fake players was true, then players could use attack mobs without meeting the required skill levels. (I fixed this and also included the fix in the other events even though they seemed to somehow be working already).