### PR TITLE
Make onTooltip more efficient

### DIFF
--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -268,12 +268,19 @@ public class LevelLockHandler {
         }
     }
 
+    private static ItemStack lastItem;
+    private static RequirementHolder lastLock = EMPTY_LOCK;
+
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
     public static void onTooltip(ItemTooltipEvent event) {
-        RequirementHolder lock = getSkillLock(event.getItemStack());
+        ItemStack current = event.getItemStack();
+        if (lastItem != current) {
+            lastItem = current;
+            lastLock = getSkillLock(current);
+        }
         PlayerData data = PlayerDataHandler.get(Minecraft.getMinecraft().player);
-        lock.addRequirementsToTooltip(data, event.getToolTip());
+        lastLock.addRequirementsToTooltip(data, event.getToolTip());
     }
 
 }


### PR DESCRIPTION
When I was debugging #54 I noticed that onTooltip gets called almost continuously while hovering over the same item (for example when you are reading the lock requirements). This pull request caches the last ItemStack and only recalculates the lock requirements if the ItemStack has changed.

This does not cover the edge case of if a new lock was added or an old one removed without them changing what item they are hovering. (Currently there is no logic for removing a lock I can add that to #54 if you wish similar to how I added a method for adding a lock properly). This is easily fixed by adding two lines that set lastItem to null and lastLock to EMPTY_LOCK in the addToLock method and if one is created a removeFromLock method.

EDIT: Thinking about it at least for now I am not going to bother creating a removeFromLock method as it will require more logic having to do with metadata vs wildcard metadata. I may attempt to create such a method when I work on making tinker's material support.