### PR TITLE
Generalize LevelLockHandler and better (and extensible) NBT support

### DIFF
--- a/src/main/java/codersafterdark/reskillable/api/data/EmptyLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/EmptyLockKey.java
@@ -1,5 +1,0 @@
-package codersafterdark.reskillable.api.data;
-
-public final class EmptyLockKey implements LockKey {
-
-}

--- a/src/main/java/codersafterdark/reskillable/api/data/EmptyLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/EmptyLockKey.java
@@ -1,0 +1,5 @@
+package codersafterdark.reskillable.api.data;
+
+public final class EmptyLockKey implements LockKey {
+
+}

--- a/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
@@ -21,11 +21,6 @@ public class GenericNBTLockKey implements NBTLockKey {
     }
 
     @Override
-    public NBTLockKey fromItemStack(ItemStack stack) {
-        return new GenericNBTLockKey(stack.getTagCompound());
-    }
-
-    @Override
     public LockKey withoutTag() {
         return null;
     }

--- a/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
@@ -12,7 +12,7 @@ public class GenericNBTLockKey implements NBTLockKey {
 
     //TODO potentially remove, this is just for reverse building
     public GenericNBTLockKey(ItemStack stack) {
-        this.tag = stack.getTagCompound();
+        this(stack.getTagCompound());
     }
 
     @Override
@@ -28,5 +28,15 @@ public class GenericNBTLockKey implements NBTLockKey {
     @Override
     public LockKey withoutTag() {
         return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof GenericNBTLockKey && (tag == null ? ((GenericNBTLockKey) o).tag == null : tag.equals(((GenericNBTLockKey) o).tag));
+    }
+
+    @Override
+    public int hashCode() {
+        return tag == null ? super.hashCode() : tag.hashCode();
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
@@ -1,0 +1,32 @@
+package codersafterdark.reskillable.api.data;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class GenericNBTLockKey implements NBTLockKey {
+    private NBTTagCompound tag;
+
+    public GenericNBTLockKey(NBTTagCompound tag) {
+        this.tag = tag;
+    }
+
+    //TODO potentially remove, this is just for reverse building
+    public GenericNBTLockKey(ItemStack stack) {
+        this.tag = stack.getTagCompound();
+    }
+
+    @Override
+    public NBTTagCompound getTag() {
+        return tag;
+    }
+
+    @Override
+    public NBTLockKey fromItemStack(ItemStack stack) {
+        return new GenericNBTLockKey(stack.getTagCompound());
+    }
+
+    @Override
+    public LockKey withoutTag() {
+        return null;
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/GenericNBTLockKey.java
@@ -10,7 +10,6 @@ public class GenericNBTLockKey implements NBTLockKey {
         this.tag = tag;
     }
 
-    //TODO potentially remove, this is just for reverse building
     public GenericNBTLockKey(ItemStack stack) {
         this(stack.getTagCompound());
     }

--- a/src/main/java/codersafterdark/reskillable/api/data/ItemInfo.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ItemInfo.java
@@ -32,11 +32,6 @@ public class ItemInfo implements NBTLockKey {
     }
 
     @Override
-    public NBTLockKey fromItemStack(ItemStack stack) {
-        return new ItemInfo(stack.getItem(), stack.getMetadata(), stack.getTagCompound());
-    }
-
-    @Override
     public LockKey withoutTag() {
         return tag == null ? this : new ItemInfo(item, metadata);
     }

--- a/src/main/java/codersafterdark/reskillable/api/data/ItemInfo.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ItemInfo.java
@@ -1,12 +1,13 @@
 package codersafterdark.reskillable.api.data;
 
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.oredict.OreDictionary;
 
 import java.util.Objects;
 
-public class ItemInfo implements LockKey {
+public class ItemInfo implements NBTLockKey {
     private int metadata;
     private Item item;
     private NBTTagCompound tag;
@@ -21,8 +22,19 @@ public class ItemInfo implements LockKey {
         this.tag = tag;
     }
 
+    @Override
     public NBTTagCompound getTag() {
         return this.tag;
+    }
+
+    @Override
+    public NBTLockKey fromItemStack(ItemStack stack) {
+        return new ItemInfo(stack.getItem(), stack.getMetadata(), stack.getTagCompound());
+    }
+
+    @Override
+    public LockKey withoutTag() {
+        return tag == null ? this : new ItemInfo(item, metadata);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/data/ItemInfo.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ItemInfo.java
@@ -22,6 +22,10 @@ public class ItemInfo implements NBTLockKey {
         this.tag = tag;
     }
 
+    public ItemInfo(ItemStack stack) {
+        this(stack.getItem(), stack.getMetadata(), stack.getTagCompound());
+    }
+
     @Override
     public NBTTagCompound getTag() {
         return this.tag;

--- a/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
@@ -17,6 +17,16 @@ public class ModLockKey implements LockKey, NBTLockKey {
         this.tag = tag;
     }
 
+    public ModLockKey(ItemStack stack) {
+        ResourceLocation registryName = stack.getItem().getRegistryName();
+        if (registryName == null) {
+            modName = "";
+        } else {
+            modName = registryName.getResourceDomain();
+            tag = stack.getTagCompound();
+        }
+    }
+
     @Override
     public NBTTagCompound getTag() {
         return tag;

--- a/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
@@ -4,6 +4,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
+import java.util.Objects;
+
 public class ModLockKey implements LockKey, NBTLockKey {
     private final String modName;
     private NBTTagCompound tag;
@@ -50,6 +52,6 @@ public class ModLockKey implements LockKey, NBTLockKey {
 
     @Override
     public int hashCode() {
-        return modName.hashCode();
+        return Objects.hash(modName, tag);
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
@@ -33,15 +33,6 @@ public class ModLockKey implements LockKey, NBTLockKey {
     }
 
     @Override
-    public NBTLockKey fromItemStack(ItemStack stack) {
-        ResourceLocation registryName = stack.getItem().getRegistryName();
-        if (registryName == null) {
-            return null;
-        }
-        return new ModLockKey(registryName.getResourceDomain(), stack.getTagCompound());
-    }
-
-    @Override
     public LockKey withoutTag() {
         return tag == null ? this : new ModLockKey(modName);
     }

--- a/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
@@ -9,7 +9,7 @@ public class ModLockKey implements LockKey, NBTLockKey {
     private NBTTagCompound tag;
 
     public ModLockKey(String modName) {
-        this.modName = modName.toLowerCase();
+        this.modName = modName == null ? "" : modName.toLowerCase();
     }
 
     public ModLockKey(String modName, NBTTagCompound tag) {
@@ -47,8 +47,14 @@ public class ModLockKey implements LockKey, NBTLockKey {
     }
 
     @Override
-    public boolean equals(Object o) {//TODO make it check if the tags are equal
-        return o == this || o instanceof ModLockKey && modName.equals(((ModLockKey) o).modName);
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof ModLockKey && modName.equals(((ModLockKey) o).modName)) {
+            return tag == null ? ((ModLockKey) o).tag == null : tag.equals(((ModLockKey) o).tag);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/ModLockKey.java
@@ -1,14 +1,43 @@
 package codersafterdark.reskillable.api.data;
 
-public class ModLockKey implements LockKey {
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+
+public class ModLockKey implements LockKey, NBTLockKey {
     private final String modName;
+    private NBTTagCompound tag;
 
     public ModLockKey(String modName) {
         this.modName = modName.toLowerCase();
     }
 
+    public ModLockKey(String modName, NBTTagCompound tag) {
+        this(modName);
+        this.tag = tag;
+    }
+
     @Override
-    public boolean equals(Object o) {
+    public NBTTagCompound getTag() {
+        return tag;
+    }
+
+    @Override
+    public NBTLockKey fromItemStack(ItemStack stack) {
+        ResourceLocation registryName = stack.getItem().getRegistryName();
+        if (registryName == null) {
+            return null;
+        }
+        return new ModLockKey(registryName.getResourceDomain(), stack.getTagCompound());
+    }
+
+    @Override
+    public LockKey withoutTag() {
+        return tag == null ? this : new ModLockKey(modName);
+    }
+
+    @Override
+    public boolean equals(Object o) {//TODO make it check if the tags are equal
         return o == this || o instanceof ModLockKey && modName.equals(((ModLockKey) o).modName);
     }
 

--- a/src/main/java/codersafterdark/reskillable/api/data/NBTLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/NBTLockKey.java
@@ -1,0 +1,12 @@
+package codersafterdark.reskillable.api.data;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface NBTLockKey extends LockKey {
+    NBTTagCompound getTag();
+
+    NBTLockKey fromItemStack(ItemStack stack);
+
+    LockKey withoutTag();
+}

--- a/src/main/java/codersafterdark/reskillable/api/data/NBTLockKey.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/NBTLockKey.java
@@ -1,12 +1,9 @@
 package codersafterdark.reskillable.api.data;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 public interface NBTLockKey extends LockKey {
     NBTTagCompound getTag();
-
-    NBTLockKey fromItemStack(ItemStack stack);
 
     LockKey withoutTag();
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementRegistry.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementRegistry.java
@@ -37,6 +37,12 @@ public class RequirementRegistry {
                 }
             }
 
+        } else if (requirements.length > 2) {
+            String requirementType = requirements[0];
+            if (requirementHandlers.containsKey(requirementType)) {
+                //Pass them the whole extended requirement Inputs (Note: they will have to split by | themselves
+                requirement = requirementHandlers.get(requirementType).apply(requirementString.replaceFirst(requirementType + '|', ""));
+            }
         }
         return Objects.requireNonNull(requirement, "Invalid Level Lock for Input: " + requirementString);
     }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementRegistry.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementRegistry.java
@@ -41,7 +41,7 @@ public class RequirementRegistry {
             String requirementType = requirements[0];
             if (requirementHandlers.containsKey(requirementType)) {
                 //Pass them the whole extended requirement Inputs (Note: they will have to split by | themselves
-                requirement = requirementHandlers.get(requirementType).apply(requirementString.replaceFirst(requirementType + '|', ""));
+                requirement = requirementHandlers.get(requirementType).apply(requirementString.replaceFirst(requirementType + "\\|", ""));
             }
         }
         return Objects.requireNonNull(requirement, "Invalid Level Lock for Input: " + requirementString);

--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -163,17 +163,21 @@ public class LevelLockHandler {
         return stack == null || stack.isEmpty() ? EMPTY_LOCK : getLocks(stack);
     }
 
+    //If this does not return "guess" the correct registered type use below method where you tell it the type
+    public static <T> RequirementHolder getLocks(T toCheck) {
+        return toCheck == null ? EMPTY_LOCK : getLocks(toCheck.getClass(), toCheck);
+    }
+
     /**
      * Gets all the locks the given object has on it.
      * @param toCheck The object to retrieve the locks of.
      * @param <T>     Represents the type of the object to check, must be registered using {@link #registerLockKey(Class, Class[])}
      * @return A RequirementHolder of all he locks for the given object.
      */
-    public static <T> RequirementHolder getLocks(T toCheck) {
+    public static <T> RequirementHolder getLocks(Class<? extends T> classType, T toCheck) {
         if (toCheck == null) {
             return EMPTY_LOCK;
         }
-        Class<?> classType = toCheck.getClass();
 
         if (!lockTypesMap.containsKey(classType)) {
             return EMPTY_LOCK;

--- a/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/LevelLockHandler.java
@@ -89,16 +89,6 @@ public class LevelLockHandler {
                 }
             }
         }
-        //TODO remove hardcoded tests
-        try {
-            addLockByKey(new GenericNBTLockKey(JsonToNBT.getTagFromJson("{ench:[{id: 33s}]}")), RequirementHolder.fromString("reskillable:magic|10"));
-
-            addLockByKey(new ModLockKey("minecraft"), RequirementHolder.fromString("reskillable:building|4"));
-
-            addLockByKey(new ModLockKey("minecraft", JsonToNBT.getTagFromJson("{ench:[{id: 34s}]}")), RequirementHolder.fromString("reskillable:gathering|6"));
-        } catch (NBTException e) {
-            e.printStackTrace();
-        }
     }
 
     private static void registerDefaultLockKeys() {
@@ -159,7 +149,7 @@ public class LevelLockHandler {
         return locks.containsKey(key) ? locks.get(key) : EMPTY_LOCK;
     }
 
-    //TODO is there a way to not do this for EVERY item on load of JEI
+    //TODO is there a way to not do this for EVERY item on load? JEI gets the tooltip of every item when it registers it (not sure if they cache the output or not)
     public static RequirementHolder getSkillLock(ItemStack stack) {
         return stack == null || stack.isEmpty() ? EMPTY_LOCK : getLocks(stack);
     }


### PR DESCRIPTION
Rewrote parts of LevelLockHandler so that locks can be more generic. It is now possible to specify different LockKey implementations as lock types to check for specific object types. (The reason that sentence doesn't make much sense is because the new code has a good amount of Generics so it is hard to explain broadly.)

For example by default I register ItemInfo, ModLockKey, and GenericNBTLockKey as LockKeys that can have their data be determined by an ItemStack. The code is then able to check for ItemStacks, what LockKeys can be created (the three I listed above), and checks to see if there is a lock registered to that information. If the LockKey implementation also implements NBTLockKey (as those three above do) it attempts to see if there is a partial match against any locks of those type. Finally it builds a list of the highest Requirements of the locks that an item falls under.

It is possible to use this for custom objects as well (not only ItemStacks). In addition, if the custom object has NBT data if you implement NBTLockKey it will automatically check if there is a partial or complete NBT match.

Copy of text I sent in the discord channel describing it with an example:

```
Generic lock: silk touch -> magic 10

Mod lock:
minecraft -> building 4
minecraft and unbreaking -> gathering 6


As can be seen in the gif below any tool with silk touch (including tinkers) requires magic 10, all blocks from minecraft require building 4 (this already is supported except I am actually summing the requirements instead of ignoring them if a tool has a specific lock), all tools/blocks from minecraft with the unbreaking enchantment require gather 6.

https://gyazo.com/d730480f803ae409928c161a0b112b00
```