### PR TITLE
Improved math for level to Rank and Rank to image

### DIFF
--- a/src/main/java/codersafterdark/reskillable/api/data/PlayerSkillInfo.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/PlayerSkillInfo.java
@@ -69,7 +69,7 @@ public class PlayerSkillInfo {
     }
 
     public int getRank() {
-        return level / (skill.getCap() / 7);
+        return 8 * level / skill.getCap();
     }
 
     public int getSkillPoints() {

--- a/src/main/java/codersafterdark/reskillable/api/skill/Skill.java
+++ b/src/main/java/codersafterdark/reskillable/api/skill/Skill.java
@@ -62,7 +62,8 @@ public abstract class Skill extends IForgeRegistryEntry.Impl<Skill> implements C
     }
 
     public Pair<Integer, Integer> getSpriteFromRank(int rank) {
-        return new MutablePair<>(Math.min(rank, 3) * 16, 0);
+        //TODO: If we ever end up having more images than 4 when the Math.min is changed make sure to also change the value rank is divided by
+        return new MutablePair<>(Math.min(rank / 2, 3) * 16, 0);
     }
 
     @Override


### PR DESCRIPTION
Makes it so that if the rank count is not divisible it handlers it better. For example if the max rank is 20 the old algorithm would break down (and also was not taking into account that there are 9 different rank names). With the current algorithm some of the ranks did not even have localized names when the max rank was 20.

image 0
ranks: 0, 1
image 1
ranks: 2, 3
image 2
ranks: 4, 5
image 3
ranks 6, 7, 8
Rank 8 is when the skill is capped