### PR TITLE
Improve performance of events

### DIFF
--- a/src/main/java/codersafterdark/reskillable/skill/attack/TraitBattleSpirit.java
+++ b/src/main/java/codersafterdark/reskillable/skill/attack/TraitBattleSpirit.java
@@ -19,7 +19,7 @@ public class TraitBattleSpirit extends Trait {
 
     @Override
     public void onKillMob(LivingDeathEvent event) {
-        if (event.getEntity() instanceof IMob && event.getSource().getTrueSource() instanceof EntityPlayer) {
+        if (!event.isCanceled() && event.getEntity() instanceof IMob && event.getSource().getTrueSource() instanceof EntityPlayer) {
             ((EntityPlayer) event.getSource().getTrueSource()).addPotionEffect(new PotionEffect(MobEffects.STRENGTH, 120, 0));
         }
     }

--- a/src/main/java/codersafterdark/reskillable/skill/attack/TraitNeutralissse.java
+++ b/src/main/java/codersafterdark/reskillable/skill/attack/TraitNeutralissse.java
@@ -24,6 +24,9 @@ public class TraitNeutralissse extends Trait {
 
     @Override
     public void onAttackMob(LivingHurtEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
         if (event.getEntity() instanceof EntityCreeper) {
             EntityCreeper creeper = (EntityCreeper) event.getEntity();
             int time = ReflectionHelper.getPrivateValue(EntityCreeper.class, creeper, LibObfuscation.TIME_SINCE_IGNITED);
@@ -35,7 +38,7 @@ public class TraitNeutralissse extends Trait {
 
     @SubscribeEvent
     public void entityTick(LivingUpdateEvent event) {
-        if (event.getEntity() instanceof EntityCreeper) {
+        if (!event.isCanceled() && event.getEntity() instanceof EntityCreeper) {
             EntityCreeper creeper = (EntityCreeper) event.getEntity();
             int defuseTime = creeper.getEntityData().getInteger(TAG_DEFUSED);
             if (defuseTime > 0) {

--- a/src/main/java/codersafterdark/reskillable/skill/building/TraitTransmutation.java
+++ b/src/main/java/codersafterdark/reskillable/skill/building/TraitTransmutation.java
@@ -26,6 +26,9 @@ public abstract class TraitTransmutation extends Trait {
 
     @Override
     public void onRightClickBlock(RightClickBlock event) {
+        if (event.isCanceled()) {
+            return;
+        }
         ItemStack stack = event.getItemStack();
         if (ItemStack.areItemsEqual(stack, reagent)) {
             IBlockState state = event.getWorld().getBlockState(event.getPos());

--- a/src/main/java/codersafterdark/reskillable/skill/defense/TraitEffectTwist.java
+++ b/src/main/java/codersafterdark/reskillable/skill/defense/TraitEffectTwist.java
@@ -36,6 +36,9 @@ public class TraitEffectTwist extends Trait {
 
     @Override
     public void onHurt(LivingHurtEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
         Entity src = event.getSource().getTrueSource();
         if (src instanceof EntityLivingBase && src instanceof IMob && src.world.rand.nextBoolean()) {
             List<PotionEffect> effects = event.getEntityLiving().getActivePotionEffects().stream().filter((p) -> badPotions.containsKey(p.getPotion())).collect(Collectors.toList());

--- a/src/main/java/codersafterdark/reskillable/skill/defense/TraitUndershirt.java
+++ b/src/main/java/codersafterdark/reskillable/skill/defense/TraitUndershirt.java
@@ -19,6 +19,9 @@ public class TraitUndershirt extends Trait {
 
     @Override
     public void onHurt(LivingHurtEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
         EntityLivingBase e = event.getEntityLiving();
         if (e.getEntityData().getInteger(TAG_COOLDOWN) == 0 && e.getHealth() >= 6 && event.getAmount() >= e.getHealth() && !event.getSource().isUnblockable()) {
             event.setAmount(e.getHealth() - 1);

--- a/src/main/java/codersafterdark/reskillable/skill/gathering/TraitDropGuarantee.java
+++ b/src/main/java/codersafterdark/reskillable/skill/gathering/TraitDropGuarantee.java
@@ -20,6 +20,9 @@ public class TraitDropGuarantee extends Trait {
 
     @Override
     public void onMobDrops(LivingDropsEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
         Entity e = event.getEntity();
         if (event.getDrops().isEmpty() && e.getEntityWorld().getGameRules().getBoolean("doMobLoot")) {
             ItemStack drop = null;

--- a/src/main/java/codersafterdark/reskillable/skill/magic/TraitSafePort.java
+++ b/src/main/java/codersafterdark/reskillable/skill/magic/TraitSafePort.java
@@ -15,7 +15,9 @@ public class TraitSafePort extends Trait {
 
     @Override
     public void onEnderTeleport(EnderTeleportEvent event) {
-        event.setAttackDamage(0);
+        if (!event.isCanceled()) {
+            event.setAttackDamage(0);
+        }
     }
 
 }

--- a/src/main/java/codersafterdark/reskillable/skill/mining/TraitObsidianSmasher.java
+++ b/src/main/java/codersafterdark/reskillable/skill/mining/TraitObsidianSmasher.java
@@ -20,6 +20,9 @@ public class TraitObsidianSmasher extends Trait {
 
     @Override
     public void getBreakSpeed(BreakSpeed event) {
+        if (event.isCanceled()) {
+            return;
+        }
         EntityPlayer player = event.getEntityPlayer();
         IBlockState state = event.getState();
 


### PR DESCRIPTION
- Biggest of which is changing PlayerTickEvent to LivingEquipmentChangeEvent so that it gets fired a lot less often and only has to check the changed slot

Add check to all cancellable events to not bother performing the checks if the event is already cancelled.
- This includes the events of traits we implement as we know they aren't going to suddenly set the event to not cancelled