### PR TITLE
Custom Skill and Trait updating

### DIFF
--- a/src/main/java/codersafterdark/reskillable/api/skill/Skill.java
+++ b/src/main/java/codersafterdark/reskillable/api/skill/Skill.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class Skill extends IForgeRegistryEntry.Impl<Skill> implements Comparable<Skill> {
-    private final ResourceLocation background;
     private final ResourceLocation spriteLocation;
     private final String name;
     private final List<Unlockable> unlockables = new ArrayList<>();
-    private SkillConfig skillConfig;
+    protected ResourceLocation background;
+    protected SkillConfig skillConfig;
 
     public Skill(ResourceLocation name, ResourceLocation background) {
         this.name = name.toString().replace(":", ".");

--- a/src/main/java/codersafterdark/reskillable/api/unlockable/Unlockable.java
+++ b/src/main/java/codersafterdark/reskillable/api/unlockable/Unlockable.java
@@ -15,23 +15,28 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public abstract class Unlockable extends IForgeRegistryEntry.Impl<Unlockable> implements Comparable<Unlockable> {
-
-    public final int x;
-    public final int y;
     private final String name;
     private final ResourceLocation icon;
-    private Skill parentSkill;
-    private ResourceLocation skillName;
-    private UnlockableConfig unlockableConfig;
+    protected Skill parentSkill;
+    protected UnlockableConfig unlockableConfig;
 
     public Unlockable(ResourceLocation name, int x, int y, ResourceLocation skillName, int cost, String... defaultRequirements) {
         this.name = name.toString().replace(":", ".");
-        this.x = x;
-        this.y = y;
-        this.skillName = skillName;
         setRegistryName(name);
         icon = new ResourceLocation(name.getResourceDomain(), "textures/unlockables/" + name.getResourcePath() + ".png");
         this.unlockableConfig = ReskillableAPI.getInstance().getTraitConfig(name, x, y, cost, defaultRequirements);
+        setParentSkill(skillName);
+    }
+
+    protected void setParentSkill(ResourceLocation skillName) {
+        if (parentSkill != null)  {
+            if (skillName != null && skillName.equals(parentSkill.getRegistryName())) {
+                //The skill is already the parent skill
+                return;
+            }
+            //Remove from old parent skill if there already is a parent skill
+            parentSkill.getUnlockables().remove(this);
+        }
         parentSkill = Objects.requireNonNull(ReskillableRegistries.SKILLS.getValue(skillName));
         if (isEnabled()) {
             if (parentSkill.isEnabled()) {

--- a/src/main/java/codersafterdark/reskillable/api/unlockable/Unlockable.java
+++ b/src/main/java/codersafterdark/reskillable/api/unlockable/Unlockable.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 public abstract class Unlockable extends IForgeRegistryEntry.Impl<Unlockable> implements Comparable<Unlockable> {
     private final String name;
     private final ResourceLocation icon;
-    protected Skill parentSkill;
+    private Skill parentSkill;
     protected UnlockableConfig unlockableConfig;
 
     public Unlockable(ResourceLocation name, int x, int y, ResourceLocation skillName, int cost, String... defaultRequirements) {


### PR DESCRIPTION
Modify Skills and Unlockables so that implementations can access and update the configs

This is so that if a custom skill or trait is updated via the CrT script it is able update the values and also allows support in CompatSkills for enabling setting the config values for skills and traits via CrT methods.