### PR TITLE
Commands

### DIFF
--- a/src/main/java/codersafterdark/reskillable/Reskillable.java
+++ b/src/main/java/codersafterdark/reskillable/Reskillable.java
@@ -3,6 +3,7 @@ package codersafterdark.reskillable;
 import codersafterdark.reskillable.api.ReskillableAPI;
 import codersafterdark.reskillable.base.CommonProxy;
 import codersafterdark.reskillable.base.ConfigHandler;
+import codersafterdark.reskillable.commands.ReskillableCmd;
 import codersafterdark.reskillable.lib.LibMisc;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -51,6 +52,8 @@ public class Reskillable {
 
     @EventHandler
     public void serverStarting(FMLServerStartingEvent event) {
+        event.registerServerCommand(new ReskillableCmd());
+
         proxy.serverStarting(event);
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/data/PlayerData.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/PlayerData.java
@@ -18,6 +18,7 @@ import net.minecraftforge.event.world.BlockEvent.HarvestDropsEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
 
 import java.lang.ref.WeakReference;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.TreeSet;
@@ -43,6 +44,10 @@ public class PlayerData {
 
     public PlayerSkillInfo getSkillInfo(Skill s) {
         return skillInfo.get(s);
+    }
+
+    public Collection<PlayerSkillInfo> getAllSkillInfo() {
+        return skillInfo.values();
     }
 
     public boolean hasAnyAbilities() {

--- a/src/main/java/codersafterdark/reskillable/api/data/PlayerSkillInfo.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/PlayerSkillInfo.java
@@ -96,11 +96,24 @@ public class PlayerSkillInfo {
         }
     }
 
+    //TODO decide if this should just call setLevel(level + 1);
     public void levelUp() {
         level++;
         if (level % skill.getSkillPointInterval() == 0) {
             skillPoints++;
         }
+    }
+
+    public void setLevel(int level) {
+        int interval = skill.getSkillPointInterval();
+        skillPoints += level / interval - this.level / interval;
+        this.level = level;
+    }
+
+    public void lock(Unlockable u, EntityPlayer p) {
+        skillPoints += u.getCost();
+        unlockables.remove(u);
+        u.onLock(p);
     }
 
     public void unlock(Unlockable u, EntityPlayer p) {
@@ -121,5 +134,4 @@ public class PlayerSkillInfo {
             }
         });
     }
-
 }

--- a/src/main/java/codersafterdark/reskillable/api/event/LevelUpEvent.java
+++ b/src/main/java/codersafterdark/reskillable/api/event/LevelUpEvent.java
@@ -8,11 +8,13 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 public class LevelUpEvent extends PlayerEvent {
     private Skill skill;
     private int level;
+    private int oldLevel;
 
-    protected LevelUpEvent(EntityPlayer player, Skill skill, int level) {
+    protected LevelUpEvent(EntityPlayer player, Skill skill, int level, int oldLevel) {
         super(player);
         this.skill = skill;
         this.level = level;
+        this.oldLevel = oldLevel;
     }
 
     public Skill getSkill() {
@@ -23,16 +25,28 @@ public class LevelUpEvent extends PlayerEvent {
         return level;
     }
 
+    public int getOldLevel() {
+        return oldLevel;
+    }
+
     @Cancelable
     public static class Pre extends LevelUpEvent {
         public Pre(EntityPlayer player, Skill skill, int level) {
-            super(player, skill, level);
+            this(player, skill, level, level - 1);
+        }
+
+        public Pre(EntityPlayer player, Skill skill, int level, int oldLevel) {
+            super(player, skill, level, oldLevel);
         }
     }
 
     public static class Post extends LevelUpEvent {
         public Post(EntityPlayer player, Skill skill, int level) {
-            super(player, skill, level);
+            this(player, skill, level, level - 1);
+        }
+
+        public Post(EntityPlayer player, Skill skill, int level, int oldLevel) {
+            super(player, skill, level, oldLevel);
         }
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/event/LockUnlockableEvent.java
+++ b/src/main/java/codersafterdark/reskillable/api/event/LockUnlockableEvent.java
@@ -1,0 +1,32 @@
+package codersafterdark.reskillable.api.event;
+
+import codersafterdark.reskillable.api.unlockable.Unlockable;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+public class LockUnlockableEvent extends PlayerEvent {
+    private Unlockable unlockable;
+
+    protected LockUnlockableEvent(EntityPlayer player, Unlockable unlockable) {
+        super(player);
+        this.unlockable = unlockable;
+    }
+
+    public Unlockable getUnlockable() {
+        return unlockable;
+    }
+
+    @Cancelable
+    public static class Pre extends LockUnlockableEvent {
+        public Pre(EntityPlayer player, Unlockable unlockable) {
+            super(player, unlockable);
+        }
+    }
+
+    public static class Post extends LockUnlockableEvent {
+        public Post(EntityPlayer player, Unlockable unlockable) {
+            super(player, unlockable);
+        }
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementRegistry.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementRegistry.java
@@ -40,8 +40,8 @@ public class RequirementRegistry {
         } else if (requirements.length > 2) {
             String requirementType = requirements[0];
             if (requirementHandlers.containsKey(requirementType)) {
-                //Pass them the whole extended requirement Inputs (Note: they will have to split by | themselves
-                requirement = requirementHandlers.get(requirementType).apply(requirementString.replaceFirst(requirementType + "\\|", ""));
+                //Pass them the whole extended requirement Inputs (Note: they will have to split by | themselves)
+                requirement = requirementHandlers.get(requirementType).apply(requirementString.substring(requirementType.length() + 1));
             }
         }
         if (requirement == null) {

--- a/src/main/java/codersafterdark/reskillable/api/unlockable/Unlockable.java
+++ b/src/main/java/codersafterdark/reskillable/api/unlockable/Unlockable.java
@@ -76,6 +76,9 @@ public abstract class Unlockable extends IForgeRegistryEntry.Impl<Unlockable> im
     public void onUnlock(EntityPlayer player) {
     }
 
+    public void onLock(EntityPlayer player) {
+    }
+
     public boolean hasSpikes() {
         return false;
     }

--- a/src/main/java/codersafterdark/reskillable/commands/CmdIncrementSkill.java
+++ b/src/main/java/codersafterdark/reskillable/commands/CmdIncrementSkill.java
@@ -23,17 +23,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class CmdResetSkill extends CommandBase {
+public class CmdIncrementSkill extends CommandBase {
     @Nonnull
     @Override
     public String getName() {
-        return "resetskill";
+        return "incrementskill";
     }
 
     @Nonnull
     @Override
     public String getUsage(@Nonnull ICommandSender sender) {
-        return "reskillable.command.resetskill.usage";
+        return "reskillable.command.incrementskill.usage";
     }
 
     @Override
@@ -54,13 +54,12 @@ public class CmdResetSkill extends CommandBase {
         PlayerData data = PlayerDataHandler.get(player);
         PlayerSkillInfo skillInfo = data.getSkillInfo(skill);
         int oldLevel = skillInfo.getLevel();
-        if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, 1, oldLevel))) {
-            skillInfo.setLevel(1);
-            skillInfo.respec();
-            MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, 1, oldLevel));
-            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.resetskill", skillName, player.getDisplayName()));
+        if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, oldLevel + 1, oldLevel))) {
+            skillInfo.levelUp();
+            MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, skillInfo.getLevel(), oldLevel));
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.skillup", skillName, player.getDisplayName()));
         } else {
-            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.resetskill", skillName, player.getDisplayName()));
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.skillup", skillName, player.getDisplayName()));
         }
         data.saveAndSync();
     }

--- a/src/main/java/codersafterdark/reskillable/commands/CmdResetAll.java
+++ b/src/main/java/codersafterdark/reskillable/commands/CmdResetAll.java
@@ -1,17 +1,14 @@
 package codersafterdark.reskillable.commands;
 
-import codersafterdark.reskillable.api.ReskillableRegistries;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.data.PlayerSkillInfo;
 import codersafterdark.reskillable.api.event.LevelUpEvent;
-import codersafterdark.reskillable.api.skill.Skill;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.common.MinecraftForge;
@@ -20,49 +17,48 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class CmdResetSkill extends CommandBase {
+public class CmdResetAll extends CommandBase {
     @Nonnull
     @Override
     public String getName() {
-        return "resetskill";
+        return "resetall";
     }
 
     @Nonnull
     @Override
     public String getUsage(@Nonnull ICommandSender sender) {
-        return "reskillable.command.resetskill.usage";
+        return "reskillable.command.resetall.usage";
     }
 
     @Override
     public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) throws CommandException {
         if (args.length == 0) {
-            throw new CommandException("reskillable.command.invalid.missing.playerskill");
-        }
-        if (args.length == 1) {
-            throw new CommandException("reskillable.command.invalid.missing.skill");
+            throw new CommandException("reskillable.command.invalid.missing.player");
         }
         EntityPlayerMP player = getPlayer(server, sender, args[0]);
-        String[] parts = args[1].split("\\.");
-        ResourceLocation skillName = parts.length > 1 ? new ResourceLocation(parts[0], args[1].substring(parts[0].length() + 1)) : new ResourceLocation(args[1]);
-        if (!ReskillableRegistries.SKILLS.containsKey(skillName)) {
-            throw new CommandException("reskillable.command.invalid.skill", skillName);
-        }
-        Skill skill = ReskillableRegistries.SKILLS.getValue(skillName);
         PlayerData data = PlayerDataHandler.get(player);
-        PlayerSkillInfo skillInfo = data.getSkillInfo(skill);
-        int oldLevel = skillInfo.getLevel();
-        if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, 1, oldLevel))) {
-            skillInfo.setLevel(1);
-            skillInfo.respec();
-            MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, 1, oldLevel));
-            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.resetskill", skillName, player.getDisplayName()));
-        } else {
-            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.resetskill", skillName, player.getDisplayName()));
+        Collection<PlayerSkillInfo> allSkils = data.getAllSkillInfo();
+        StringBuilder failedSkills = new StringBuilder();
+        for (PlayerSkillInfo skillInfo : allSkils) {
+            int oldLevel = skillInfo.getLevel();
+            if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skillInfo.skill, 1, oldLevel))) {
+                skillInfo.setLevel(1);
+                skillInfo.respec();
+                MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skillInfo.skill, 1, oldLevel));
+            } else {
+                failedSkills.append(skillInfo.skill.getName()).append(", ");
+            }
         }
         data.saveAndSync();
+        if (failedSkills.length() == 0) {
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.resetall", player.getDisplayName()));
+        } else {
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.resetall", failedSkills.substring(0, failedSkills.length() - 2), player.getDisplayName()));
+        }
     }
 
     @Nonnull
@@ -74,10 +70,6 @@ public class CmdResetSkill extends CommandBase {
         if (args.length == 1) {
             String partialName = args[0];
             return Arrays.stream(server.getPlayerList().getOnlinePlayerNames()).filter(name -> name.startsWith(partialName)).collect(Collectors.toList());
-        }
-        if (args.length == 2) {
-            String partial = args[1];
-            return ReskillableRegistries.SKILLS.getValuesCollection().stream().map(Skill::getKey).filter(skillName -> skillName.startsWith(partial)).collect(Collectors.toList());
         }
         return new ArrayList<>();
     }

--- a/src/main/java/codersafterdark/reskillable/commands/CmdResetSkill.java
+++ b/src/main/java/codersafterdark/reskillable/commands/CmdResetSkill.java
@@ -1,0 +1,61 @@
+package codersafterdark.reskillable.commands;
+
+import codersafterdark.reskillable.api.ReskillableRegistries;
+import codersafterdark.reskillable.api.skill.Skill;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CmdResetSkill extends CommandBase {
+    @Nonnull
+    @Override
+    public String getName() {
+        return "resetskill";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage(@Nonnull ICommandSender sender) {
+        return "reskillable.command.resetskill.usage";
+    }
+
+    @Override
+    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) throws CommandException {
+        //going to make a resetskill command, (which I will also have it remove any attributes you have in that skill).
+        // A setskilllevel. A command of some sort to toggle having specific traits, and then a command that basically just resets everything for a player
+        //TODO Change usage and tab complete to be /reskillable resetskill <player> <skill>
+        if (args.length == 0) {
+            //TODO error message must enter a skill
+            return;
+        }
+        ResourceLocation skillName = new ResourceLocation(args[0]);
+        if (!ReskillableRegistries.SKILLS.containsKey(skillName)) {
+            //TODO error message invalid skill
+            return;
+        }
+        Skill skill = ReskillableRegistries.SKILLS.getValue(skillName);
+
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
+        List<String> skillNames = new ArrayList<>();
+        String partial = args.length == 0 ? "" : args[0];
+        for (Skill skill : ReskillableRegistries.SKILLS.getValuesCollection()) {
+            String skillName = skill.getKey();
+            if (skillName.startsWith(partial)) {
+                skillNames.add(skillName);
+            }
+        }
+        return skillNames;
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/commands/CmdSetSkillLevel.java
+++ b/src/main/java/codersafterdark/reskillable/commands/CmdSetSkillLevel.java
@@ -22,27 +22,31 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-public class CmdResetSkill extends CommandBase {
+public class CmdSetSkillLevel extends CommandBase {
     @Nonnull
     @Override
     public String getName() {
-        return "resetskill";
+        return "setskilllevel";
     }
 
     @Nonnull
     @Override
     public String getUsage(@Nonnull ICommandSender sender) {
-        return "reskillable.command.resetskill.usage";
+        return "reskillable.command.setskilllevel.usage";
     }
 
     @Override
     public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) throws CommandException {
         if (args.length == 0) {
-            throw new CommandException("reskillable.command.invalid.missing.playerskill");
+            throw new CommandException("reskillable.command.invalid.missing.playerskilllevel");
         }
         if (args.length == 1) {
-            throw new CommandException("reskillable.command.invalid.missing.skill");
+            throw new CommandException("reskillable.command.invalid.missing.skilllevel");
+        }
+        if (args.length == 2) {
+            throw new CommandException("reskillable.command.invalid.missing.level");
         }
         EntityPlayerMP player = getPlayer(server, sender, args[0]);
         String[] parts = args[1].split("\\.");
@@ -50,17 +54,28 @@ public class CmdResetSkill extends CommandBase {
         if (!ReskillableRegistries.SKILLS.containsKey(skillName)) {
             throw new CommandException("reskillable.command.invalid.skill", skillName);
         }
+        int level;
+        try {
+            level = Integer.parseInt(args[2]);
+        } catch (NumberFormatException e) {
+            throw new CommandException("reskillable.command.invalid.level", args[2]);
+        }
+        if (level <= 0) {
+            throw new CommandException("reskillable.command.invalid.belowmin", level);
+        }
         Skill skill = ReskillableRegistries.SKILLS.getValue(skillName);
+        if (level > skill.getCap()) {
+            throw new CommandException("reskillable.command.invalid.pastcap", level, skill.getCap());
+        }
         PlayerData data = PlayerDataHandler.get(player);
         PlayerSkillInfo skillInfo = data.getSkillInfo(skill);
         int oldLevel = skillInfo.getLevel();
-        if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, 1, oldLevel))) {
-            skillInfo.setLevel(1);
-            skillInfo.respec();
-            MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, 1, oldLevel));
-            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.resetskill", skillName, player.getDisplayName()));
+        if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, level, oldLevel))) {
+            skillInfo.setLevel(level);
+            MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, level, oldLevel));
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.setskilllevel", skillName, level, player.getDisplayName()));
         } else {
-            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.resetskill", skillName, player.getDisplayName()));
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.setskilllevel", skillName, level, player.getDisplayName()));
         }
         data.saveAndSync();
     }
@@ -78,6 +93,15 @@ public class CmdResetSkill extends CommandBase {
         if (args.length == 2) {
             String partial = args[1];
             return ReskillableRegistries.SKILLS.getValuesCollection().stream().map(Skill::getKey).filter(skillName -> skillName.startsWith(partial)).collect(Collectors.toList());
+        }
+        if (args.length == 3) {
+            String[] parts = args[1].split("\\.");
+            ResourceLocation skillName = parts.length > 1 ? new ResourceLocation(parts[0], args[1].substring(parts[0].length() + 1)) : new ResourceLocation(args[1]);
+            if (ReskillableRegistries.SKILLS.containsKey(skillName)) {
+                Skill skill = ReskillableRegistries.SKILLS.getValue(skillName);
+                String level = args[2];
+                return IntStream.rangeClosed(1, skill.getCap()).mapToObj(Integer::toString).filter(iString -> iString.startsWith(level)).collect(Collectors.toList());
+            }
         }
         return new ArrayList<>();
     }

--- a/src/main/java/codersafterdark/reskillable/commands/CmdToggleTrait.java
+++ b/src/main/java/codersafterdark/reskillable/commands/CmdToggleTrait.java
@@ -1,0 +1,91 @@
+package codersafterdark.reskillable.commands;
+
+import codersafterdark.reskillable.api.ReskillableRegistries;
+import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.data.PlayerSkillInfo;
+import codersafterdark.reskillable.api.event.LockUnlockableEvent;
+import codersafterdark.reskillable.api.event.UnlockUnlockableEvent;
+import codersafterdark.reskillable.api.unlockable.Unlockable;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.common.MinecraftForge;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CmdToggleTrait extends CommandBase {
+    @Nonnull
+    @Override
+    public String getName() {
+        return "toggletrait";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage(@Nonnull ICommandSender sender) {
+        return "reskillable.command.toggletrait.usage";
+    }
+
+    @Override
+    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) throws CommandException {
+        if (args.length == 0) {
+            throw new CommandException("reskillable.command.invalid.missing.playertrait");
+        }
+        if (args.length == 1) {
+            throw new CommandException("reskillable.command.invalid.missing.trait");
+        }
+        EntityPlayerMP player = getPlayer(server, sender, args[0]);
+        String[] parts = args[1].split("\\.");
+        ResourceLocation traitName = parts.length > 1 ? new ResourceLocation(parts[0], args[1].substring(parts[0].length() + 1)) : new ResourceLocation(args[1]);
+        if (!ReskillableRegistries.UNLOCKABLES.containsKey(traitName)) {
+            throw new CommandException("reskillable.command.invalid.trait", traitName);
+        }
+        Unlockable trait = ReskillableRegistries.UNLOCKABLES.getValue(traitName);
+        PlayerData data = PlayerDataHandler.get(player);
+        PlayerSkillInfo skillInfo = data.getSkillInfo(trait.getParentSkill());
+        if (skillInfo.isUnlocked(trait)) {
+            if (!MinecraftForge.EVENT_BUS.post(new LockUnlockableEvent.Pre(player, trait))) {
+                skillInfo.lock(trait, player);
+                MinecraftForge.EVENT_BUS.post(new LockUnlockableEvent.Post(player, trait));
+                sender.sendMessage(new TextComponentTranslation("reskillable.command.success.locktrait", traitName, player.getDisplayName()));
+            } else {
+                sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.locktrait", traitName, player.getDisplayName()));
+            }
+        } else if (!MinecraftForge.EVENT_BUS.post(new UnlockUnlockableEvent.Pre(player, trait))) {
+            skillInfo.unlock(trait, player);
+            MinecraftForge.EVENT_BUS.post(new UnlockUnlockableEvent.Post(player, trait));
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.success.unlocktrait", traitName, player.getDisplayName()));
+        } else {
+            sender.sendMessage(new TextComponentTranslation("reskillable.command.fail.unlocktrait", traitName, player.getDisplayName()));
+        }
+        data.saveAndSync();
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
+        if (args.length == 0) {
+            return Arrays.asList(server.getPlayerList().getOnlinePlayerNames());
+        }
+        if (args.length == 1) {
+            String partialName = args[0];
+            return Arrays.stream(server.getPlayerList().getOnlinePlayerNames()).filter(name -> name.startsWith(partialName)).collect(Collectors.toList());
+        }
+        if (args.length == 2) {
+            String partial = args[1];
+            return ReskillableRegistries.UNLOCKABLES.getValuesCollection().stream().map(Unlockable::getKey).filter(traitName -> traitName.startsWith(partial)).collect(Collectors.toList());
+        }
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/commands/ReskillableCmd.java
+++ b/src/main/java/codersafterdark/reskillable/commands/ReskillableCmd.java
@@ -1,0 +1,26 @@
+package codersafterdark.reskillable.commands;
+
+import net.minecraft.command.ICommandSender;
+import net.minecraftforge.server.command.CommandTreeBase;
+
+import javax.annotation.Nonnull;
+
+public class ReskillableCmd extends CommandTreeBase {
+    //TODO @p and @a support for commands
+
+    public ReskillableCmd() {
+        addSubcommand(new CmdResetSkill());
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "reskillable";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage(@Nonnull ICommandSender sender) {
+        return "reskillable.command.usage";
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/commands/ReskillableCmd.java
+++ b/src/main/java/codersafterdark/reskillable/commands/ReskillableCmd.java
@@ -6,10 +6,14 @@ import net.minecraftforge.server.command.CommandTreeBase;
 import javax.annotation.Nonnull;
 
 public class ReskillableCmd extends CommandTreeBase {
-    //TODO @p and @a support for commands
+    //TODO ResetSkill and ResetAll should really make it so any skill locks or trait requirements no longer met get their state reset as well
 
     public ReskillableCmd() {
+        addSubcommand(new CmdIncrementSkill());
+        addSubcommand(new CmdResetAll());
         addSubcommand(new CmdResetSkill());
+        addSubcommand(new CmdSetSkillLevel());
+        addSubcommand(new CmdToggleTrait());
     }
 
     @Nonnull

--- a/src/main/java/codersafterdark/reskillable/network/MessageLevelUp.java
+++ b/src/main/java/codersafterdark/reskillable/network/MessageLevelUp.java
@@ -52,12 +52,13 @@ public class MessageLevelUp implements IMessage, IMessageHandler<MessageLevelUp,
         if (!info.isCapped()) {
             int cost = info.getLevelUpCost();
             if (player.experienceLevel >= cost || player.isCreative()) {
-                if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, info.getLevel() + 1))) {
+                int oldLevel = info.getLevel();
+                if (!MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Pre(player, skill, oldLevel + 1, oldLevel))) {
                     if (!player.isCreative()) {
                         ExperienceHelper.drainPlayerXP(player, ExperienceHelper.getExperienceForLevel(cost));
                     }
                     info.levelUp();
-                    MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, info.getLevel()));
+                    MinecraftForge.EVENT_BUS.post(new LevelUpEvent.Post(player, skill, info.getLevel(), oldLevel));
                 }
                 data.saveAndSync();
             }

--- a/src/main/resources/assets/reskillable/lang/en_US.lang
+++ b/src/main/resources/assets/reskillable/lang/en_US.lang
@@ -83,3 +83,7 @@ skillable.tab.abilities=Abilities
 # KEY-BINDINGS
 key.controls.reskillable=Reskillable
 key.openGUI=Open Skill GUI
+
+# COMMANDS
+reskillable.command.usage=/reskillable subcommand
+reskillable.command.resetskill.usage=/reskillable resetskill <skill>

--- a/src/main/resources/assets/reskillable/lang/en_US.lang
+++ b/src/main/resources/assets/reskillable/lang/en_US.lang
@@ -86,4 +86,36 @@ key.openGUI=Open Skill GUI
 
 # COMMANDS
 reskillable.command.usage=/reskillable subcommand
-reskillable.command.resetskill.usage=/reskillable resetskill <skill>
+reskillable.command.resetskill.usage=/reskillable resetskill <player> <skill>
+reskillable.command.setskilllevel.usage=/reskillable setskilllevel <player> <skill> <level>
+reskillable.command.incrementskill.usage=/reskillable incrementskill <player> <skill>
+reskillable.command.resetall.usage=/reskillable resetall <player>
+reskillable.command.toggletrait.usage=/reskillable toggletrait <player> <trait>
+
+reskillable.command.success.unlocktrait=Successfully unlocked '%s' for player '%s'.
+reskillable.command.success.locktrait=Successfully locked '%s' for player '%s'.
+reskillable.command.success.resetskill=Successfully reset Skill: '%s' for player '%s'.
+reskillable.command.success.setskilllevel=Successfully set the level of Skill: '%s' to '%s' for player '%s'.
+reskillable.command.success.skillup=Successfully leveled up Skill: '%s' for player '%s'.
+reskillable.command.success.resetall=Successfully reset all skills for player '%s'.
+
+reskillable.command.fail.unlocktrait=Failed to unlock '%s' for player '%s'.
+reskillable.command.fail.locktrait=Failed to lock '%s' for player '%s'.
+reskillable.command.fail.resetskill=Failed to reset Skill: '%s' for player '%s'.
+reskillable.command.fail.setskilllevel=Failed tp set the level of Skill: '%s' to '%s' for player '%s'.
+reskillable.command.fail.skillup=Failed to level up Skill: '%s' for player '%s'.
+reskillable.command.fail.resetall=Failed to reset skills '%s' for player '%s'.
+
+reskillable.command.invalid.skill=Skill '%s' is invalid.
+reskillable.command.invalid.trait=Trait '%s' is invalid.
+reskillable.command.invalid.pastcap=Level '%s' is past the cap of '%s' for that skill.
+reskillable.command.invalid.belowmin=Level '%s' is below the minimum level of '1'.
+
+reskillable.command.invalid.missing.skill=You must enter the name of a skill.
+reskillable.command.invalid.missing.trait=You must enter the name of a trait.
+reskillable.command.invalid.missing.player=You must enter the name of a player.
+reskillable.command.invalid.missing.level=You must enter a level to set the skill to.
+reskillable.command.invalid.missing.playerskill=You must enter the name of both a player and a skill.
+reskillable.command.invalid.missing.playertrait=You must enter the name of both a player and a trait.
+reskillable.command.invalid.missing.playerskilllevel=You must enter the name of both a player and a skill, and a level for the skill.
+reskillable.command.invalid.missing.skilllevel=You must enter the name of a skill, and a level for the skill.


### PR DESCRIPTION
Added some commands to help pack developers debug locks without having to restart their world to go back in levels. This closes #89
```/reskillable resetskill <player> <skill>
/reskillable setskilllevel <player> <skill> <level>
/reskillable incrementskill <player> <skill>
/reskillable resetall <player>
/reskillable toggletrait <player> <trait>```

This also adds a LockUnlockableEvent and modifies LevelUpEvent to support what the previous level is. Because the commands bypass whatever locks may be on the skills or traits directly, this was chosen over manually running levelup multiple times as the new level may be lower than the old level. This does not fully address #75 as it manually fires the events so that it can let the user know if the command was cancelled.

This pull also contains a very small change to RequirementRegistry to allow requirement types to contain special regex characters such as `*` or `.` without failing to return the proper rebuilt up info text.