### PR TITLE
Requirement caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ forge_version=14.23.4.2707
 dir_repo=./
 
 mod_name=Reskillable
-mod_version=1.6.0
+mod_version=1.7.0

--- a/src/main/java/codersafterdark/reskillable/api/ReskillableAPI.java
+++ b/src/main/java/codersafterdark/reskillable/api/ReskillableAPI.java
@@ -1,7 +1,6 @@
 package codersafterdark.reskillable.api;
 
 import codersafterdark.reskillable.api.data.PlayerData;
-import codersafterdark.reskillable.api.data.RequirementHolder;
 import codersafterdark.reskillable.api.requirement.AdvancementRequirement;
 import codersafterdark.reskillable.api.requirement.NoneRequirement;
 import codersafterdark.reskillable.api.requirement.RequirementRegistry;
@@ -26,10 +25,7 @@ public class ReskillableAPI {
     public ReskillableAPI(IModAccess modAccess) {
         this.modAccess = modAccess;
         this.requirementRegistry = new RequirementRegistry();
-        requirementRegistry.addRequirementHandler("adv", input -> {
-            Advancement adv = RequirementHolder.getAdvancementList().getAdvancement(new ResourceLocation(input));
-            return adv == null ? null : new AdvancementRequirement(adv);
-        });
+        requirementRegistry.addRequirementHandler("adv", input -> new AdvancementRequirement(new ResourceLocation(input)));
         requirementRegistry.addRequirementHandler("trait", input -> {
             Unlockable unlockable = ReskillableRegistries.UNLOCKABLES.getValue(new ResourceLocation(input));
             return unlockable == null ? null : new TraitRequirement(unlockable);

--- a/src/main/java/codersafterdark/reskillable/api/ReskillableAPI.java
+++ b/src/main/java/codersafterdark/reskillable/api/ReskillableAPI.java
@@ -1,12 +1,14 @@
 package codersafterdark.reskillable.api;
 
 import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.data.RequirementHolder;
 import codersafterdark.reskillable.api.requirement.AdvancementRequirement;
 import codersafterdark.reskillable.api.requirement.NoneRequirement;
 import codersafterdark.reskillable.api.requirement.RequirementRegistry;
 import codersafterdark.reskillable.api.requirement.TraitRequirement;
 import codersafterdark.reskillable.api.requirement.logic.LogicParser;
 import codersafterdark.reskillable.api.skill.SkillConfig;
+import codersafterdark.reskillable.api.unlockable.Unlockable;
 import codersafterdark.reskillable.api.unlockable.UnlockableConfig;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
@@ -24,8 +26,14 @@ public class ReskillableAPI {
     public ReskillableAPI(IModAccess modAccess) {
         this.modAccess = modAccess;
         this.requirementRegistry = new RequirementRegistry();
-        requirementRegistry.addRequirementHandler("adv", input -> new AdvancementRequirement(new ResourceLocation(input)));
-        requirementRegistry.addRequirementHandler("trait", input -> new TraitRequirement(new ResourceLocation(input)));
+        requirementRegistry.addRequirementHandler("adv", input -> {
+            Advancement adv = RequirementHolder.getAdvancementList().getAdvancement(new ResourceLocation(input));
+            return adv == null ? null : new AdvancementRequirement(adv);
+        });
+        requirementRegistry.addRequirementHandler("trait", input -> {
+            Unlockable unlockable = ReskillableRegistries.UNLOCKABLES.getValue(new ResourceLocation(input));
+            return unlockable == null ? null : new TraitRequirement(unlockable);
+        });
         requirementRegistry.addRequirementHandler("unobtainable", input -> LogicParser.FALSE);
         requirementRegistry.addRequirementHandler("none", input -> new NoneRequirement()); //Makes it so other requirements are ignored
 

--- a/src/main/java/codersafterdark/reskillable/api/data/PlayerData.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/PlayerData.java
@@ -3,6 +3,7 @@ package codersafterdark.reskillable.api.data;
 import codersafterdark.reskillable.api.ReskillableAPI;
 import codersafterdark.reskillable.api.ReskillableRegistries;
 import codersafterdark.reskillable.api.requirement.Requirement;
+import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.api.skill.Skill;
 import codersafterdark.reskillable.api.unlockable.Ability;
 import codersafterdark.reskillable.api.unlockable.IAbilityEventHandler;
@@ -24,13 +25,14 @@ import java.util.function.Consumer;
 public class PlayerData {
     private static final String TAG_SKILLS_CMP = "SkillLevels";
     private final boolean client;
+    private final RequirementCache requirementCache;
     public WeakReference<EntityPlayer> playerWR;
     private Map<Skill, PlayerSkillInfo> skillInfo = new HashMap<>();
-    private Map<Requirement, Boolean> requirementCache = new HashMap<>();
 
     public PlayerData(EntityPlayer player) {
         playerWR = new WeakReference<>(player);
         client = player.getEntityWorld().isRemote;
+        requirementCache = new RequirementCache(player);
 
         ReskillableRegistries.SKILLS.getValuesCollection().forEach(s -> skillInfo.put(s, new PlayerSkillInfo(s)));
 
@@ -55,46 +57,17 @@ public class PlayerData {
         return set;
     }
 
-    //TODO Cont: This will allow nested requirements and tooltips (if the code gets properly updated) to store the value
-    //TODO Cont: The value will still be valid so it can get the cached boolean because all parent checks get called before a new call to matchStats
     public boolean matchStats(RequirementHolder holder) {
-        //TODO: Improve on the caching method so that it does not have to always reset the cache when a new requirement holder is being checked.
-        //TODO Cont: This would also require a better way of deciding when something should be rechecked and how long to store the data for
-        resetRequirementCache(); //Clears the previous cache
-        EntityPlayer entityPlayer = playerWR.get();
-        if (entityPlayer != null) {
-            for (Requirement requirement : holder.getRequirements()) {
-                //TODO figure out how to cache if it has been achieved and see if it has to be updated
-                //TODO: Have a start cache and an "end" cache that removes it from being cached
-                if (!requirementAchieved(requirement)) {
-                    return false;
-                }
-            }
-        }
-        return true;
+        return playerWR.get() == null || holder.getRequirements().stream().allMatch(this::requirementAchieved);
     }
 
-    //TODO: Use this in the tooltip method of requirements, and also in the sub requirement parts of logic requirements
+    //helper method to access the requirement cache
     public boolean requirementAchieved(Requirement requirement) {
-        EntityPlayer entityPlayer = playerWR.get();
-        if (entityPlayer != null) {
-            if (requirementCache.containsKey(requirement)) {
-                return requirementCache.get(requirement);
-            }
-            boolean achieved = requirement.achievedByPlayer(entityPlayer);
-            requirementCache.put(requirement, achieved);
-            return achieved;
-        }
-        return false;
+        return getRequirementCache().requirementAchieved(requirement);
     }
 
-    //TODO: Does requirementCache get cleared often enough? For example for tooltips will it need this to be rechecked when stats/dimensions etc change
-    //TODO Cont: Potentially make this get called in specific circumstances when things may not update properly.
-    //TODO Cont: This will be needed if we want auto unlockables to be efficient
-    //TODO: Make a way to "invalidate" certain requirement types. It may not be as efficient as manually removing same skill types instead of all skill requirement caches
-    //TODO Cont: but it will probably work better. Logic Requirements probably should always be invalidated
-    public void resetRequirementCache() {
-        requirementCache.clear();
+    public final RequirementCache getRequirementCache() {
+        return requirementCache;
     }
 
     public void load() {

--- a/src/main/java/codersafterdark/reskillable/api/data/RequirementHolder.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/RequirementHolder.java
@@ -128,9 +128,16 @@ public class RequirementHolder {
         }
         if (!ConfigHandler.hideRequirements || GuiScreen.isShiftKeyDown()) {
             tooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLock").getUnformattedComponentText());
-            requirements.stream().map(requirement -> requirement.getToolTip(data)).forEach(tooltip::add);
+            addRequirementsIgnoreShift(data, tooltip);
         } else {
             tooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLockShift").getUnformattedComponentText());
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void addRequirementsIgnoreShift(PlayerData data, List<String> tooltip) {
+        if (isRealLock()) {
+            requirements.stream().map(requirement -> requirement.getToolTip(data)).forEach(tooltip::add);
         }
     }
 

--- a/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
@@ -18,7 +18,7 @@ public class AdvancementRequirement extends Requirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayer) {
-        return ReskillableAPI.getInstance().getAdvancementProgress(entityPlayer, getAdvancement()).isDone();
+        return ReskillableAPI.getInstance().getAdvancementProgress(entityPlayer, advancement).isDone();
     }
 
     public Advancement getAdvancement() {
@@ -27,7 +27,17 @@ public class AdvancementRequirement extends Requirement {
 
     @Override
     public RequirementComparision matches(Requirement other) {
-        return other instanceof AdvancementRequirement && getAdvancement().equals(((AdvancementRequirement) other).getAdvancement())
+        return other instanceof AdvancementRequirement && advancement.equals(((AdvancementRequirement) other).advancement)
                 ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof AdvancementRequirement && advancement.equals(((AdvancementRequirement) o).advancement);
+    }
+
+    @Override
+    public int hashCode() {
+        return advancement.hashCode();
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
@@ -34,7 +34,7 @@ public class AdvancementRequirement extends Requirement {
             return "";
         }
         return TextFormatting.GRAY + " - " + TextFormatting.GOLD + new TextComponentTranslation("skillable.misc.achievementFormat",
-                data == null || !achievedByPlayer(data.playerWR.get()) ? TextFormatting.RED : TextFormatting.GREEN,
+                data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN,
                 adv.getDisplayText().getUnformattedText().replaceAll("[\\[\\]]", "")).getUnformattedComponentText();
     }
 

--- a/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
@@ -1,43 +1,60 @@
 package codersafterdark.reskillable.api.requirement;
 
 import codersafterdark.reskillable.api.ReskillableAPI;
+import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.data.RequirementHolder;
 import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
-public class AdvancementRequirement extends Requirement {
-    private Advancement advancement;
+import java.util.Optional;
 
-    //TODO: Double check that this does not need to actually check the advancement later
-    public AdvancementRequirement(Advancement advancement) {
-        this.advancement = advancement;
-        this.tooltip = TextFormatting.GRAY + " - " + TextFormatting.GOLD + new TextComponentTranslation("skillable.misc.achievementFormat",
-                "%S", advancement.getDisplayText().getUnformattedText().replaceAll("[\\[\\]]", "")).getUnformattedComponentText();
+public class AdvancementRequirement extends Requirement {
+    private ResourceLocation advancementName;
+
+    public AdvancementRequirement(ResourceLocation advancementName) {
+        this.advancementName = advancementName;
+
     }
 
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayer) {
-        return ReskillableAPI.getInstance().getAdvancementProgress(entityPlayer, advancement).isDone();
+        return Optional.ofNullable(this.getAdvancement())
+                .map(advancement -> ReskillableAPI.getInstance().getAdvancementProgress(entityPlayer, advancement))
+                .map(AdvancementProgress::isDone)
+                .orElse(false);
+    }
+
+    @Override
+    public String getToolTip(PlayerData data) {
+        if (tooltip.isEmpty()) {
+            Advancement adv = getAdvancement();
+            this.tooltip = TextFormatting.GRAY + " - " + TextFormatting.GOLD + new TextComponentTranslation("skillable.misc.achievementFormat",
+                    "%S", adv == null ? "" : adv.getDisplayText().getUnformattedText().replaceAll("[\\[\\]]", "")).getUnformattedComponentText();
+        }
+        return super.getToolTip(data);
     }
 
     public Advancement getAdvancement() {
-        return advancement;
+        return RequirementHolder.getAdvancementList().getAdvancement(advancementName);
     }
 
     @Override
     public RequirementComparision matches(Requirement other) {
-        return other instanceof AdvancementRequirement && advancement.equals(((AdvancementRequirement) other).advancement)
+        return other instanceof AdvancementRequirement && advancementName.equals(((AdvancementRequirement) other).advancementName)
                 ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
 
     @Override
     public boolean equals(Object o) {
-        return o == this || o instanceof AdvancementRequirement && advancement.equals(((AdvancementRequirement) o).advancement);
+        return o == this || o instanceof AdvancementRequirement && advancementName.equals(((AdvancementRequirement) o).advancementName);
     }
 
     @Override
     public int hashCode() {
-        return advancement.hashCode();
+        return advancementName.hashCode();
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/AdvancementRequirement.java
@@ -1,45 +1,28 @@
 package codersafterdark.reskillable.api.requirement;
 
 import codersafterdark.reskillable.api.ReskillableAPI;
-import codersafterdark.reskillable.api.data.PlayerData;
-import codersafterdark.reskillable.api.data.RequirementHolder;
 import net.minecraft.advancements.Advancement;
-import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
-import java.util.Optional;
-
 public class AdvancementRequirement extends Requirement {
-    private ResourceLocation advancementName;
+    private Advancement advancement;
 
-    public AdvancementRequirement(ResourceLocation advancementName) {
-        this.advancementName = advancementName;
+    //TODO: Double check that this does not need to actually check the advancement later
+    public AdvancementRequirement(Advancement advancement) {
+        this.advancement = advancement;
+        this.tooltip = TextFormatting.GRAY + " - " + TextFormatting.GOLD + new TextComponentTranslation("skillable.misc.achievementFormat",
+                "%S", advancement.getDisplayText().getUnformattedText().replaceAll("[\\[\\]]", "")).getUnformattedComponentText();
     }
 
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayer) {
-        return Optional.ofNullable(this.getAdvancement())
-                .map(advancement -> ReskillableAPI.getInstance().getAdvancementProgress(entityPlayer, advancement))
-                .map(AdvancementProgress::isDone)
-                .orElse(false);
-    }
-
-    @Override
-    public String getToolTip(PlayerData data) {
-        Advancement adv = getAdvancement();
-        if (adv == null) {
-            return "";
-        }
-        return TextFormatting.GRAY + " - " + TextFormatting.GOLD + new TextComponentTranslation("skillable.misc.achievementFormat",
-                data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN,
-                adv.getDisplayText().getUnformattedText().replaceAll("[\\[\\]]", "")).getUnformattedComponentText();
+        return ReskillableAPI.getInstance().getAdvancementProgress(entityPlayer, getAdvancement()).isDone();
     }
 
     public Advancement getAdvancement() {
-        return RequirementHolder.getAdvancementList().getAdvancement(advancementName);
+        return advancement;
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/NoneRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/NoneRequirement.java
@@ -25,4 +25,15 @@ public final class NoneRequirement extends Requirement {
     public RequirementComparision matches(Requirement other) {
         return other instanceof NoneRequirement ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof NoneRequirement;
+    }
+
+    @Override
+    public int hashCode() {
+        //Does not actually matter but might as well have it be the same for each none requirement
+        return 2;
+    }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/NoneRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/NoneRequirement.java
@@ -7,6 +7,10 @@ import net.minecraft.util.text.TextFormatting;
 
 //This has the same body as a TrueRequirement, except that it should not simplify out
 public final class NoneRequirement extends Requirement {
+    public NoneRequirement() {
+        this.tooltip = TextFormatting.GREEN + new TextComponentTranslation("skillable.misc.unobtainableFormat").getUnformattedComponentText();
+    }
+
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayerMP) {
         return true;
@@ -14,6 +18,11 @@ public final class NoneRequirement extends Requirement {
 
     @Override
     public String getToolTip(PlayerData data) {
-        return TextFormatting.GREEN + new TextComponentTranslation("skillable.misc.unobtainableFormat").getUnformattedComponentText();
+        return tooltip;
+    }
+
+    @Override
+    public RequirementComparision matches(Requirement other) {
+        return other instanceof NoneRequirement ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/Requirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/Requirement.java
@@ -2,11 +2,20 @@ package codersafterdark.reskillable.api.requirement;
 
 import codersafterdark.reskillable.api.data.PlayerData;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.text.TextFormatting;
 
 public abstract class Requirement {
+    protected String tooltip = "";
+
     public abstract boolean achievedByPlayer(EntityPlayer entityPlayerMP);
 
-    public abstract String getToolTip(PlayerData data);
+    public String getToolTip(PlayerData data) {
+        try {
+            return String.format(internalToolTip(), data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN);
+        } catch (IllegalArgumentException e) {
+            return internalToolTip(); //If the formatting code is not there just return whatever the internal String is
+        }
+    }
 
     public RequirementComparision matches(Requirement other) {
         return equals(other) ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
@@ -15,5 +24,10 @@ public abstract class Requirement {
     //Mainly used for skills and traits. If this is false then using this requirement will log an error and ignore the requirement
     public boolean isEnabled() {
         return true;
+    }
+
+    //Should only be used if people know what they are doing
+    public final String internalToolTip() {
+        return tooltip;
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -1,0 +1,125 @@
+package codersafterdark.reskillable.api.requirement;
+
+import codersafterdark.reskillable.api.event.LevelUpEvent;
+import codersafterdark.reskillable.api.event.LockUnlockableEvent;
+import codersafterdark.reskillable.api.event.UnlockUnlockableEvent;
+import codersafterdark.reskillable.api.requirement.logic.impl.*;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.player.AdvancementEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+public class RequirementCache {
+    private static List<Class<? extends Requirement>> dirtyCacheTypes = new ArrayList<>();
+    private static Map<UUID, RequirementCache> cacheMap = new HashMap<>();
+
+    //TODO should it be requirement -> player/boolean so that it does not need to keep track of multiple requirements? They really are pointers so it should not matter
+    private Map<Requirement, Boolean> requirementCache = new HashMap<>();
+    private EntityPlayer player;
+    private boolean dirtyCache;
+
+    public RequirementCache(@Nonnull EntityPlayer player) {
+        this.player = player;
+        cacheMap.put(player.getUniqueID(), this);
+    }
+
+    public boolean requirementAchieved(Requirement requirement) {
+        if (requirementCache.containsKey(requirement)) {
+            return requirementCache.get(requirement);
+        }
+        boolean achieved = requirement.achievedByPlayer(player);
+        requirementCache.put(requirement, achieved);
+        dirtyCache = true; //TODO: Decide if this should only add as dirty if the type matches one of the dirtyCacheTypes. Would potentially improve performance
+        return achieved;
+    }
+
+    public void invalidateCache(Class<? extends Requirement> cacheType) {
+        List<Class<? extends Requirement>> dirtyTypes = null;
+        if (dirtyCache) {
+            //Clear all types that are supposed to be invalidated each time
+            dirtyTypes = new ArrayList<>(dirtyCacheTypes);
+            if (cacheType != null) {
+                dirtyTypes.add(cacheType);
+            }
+        } else if (cacheType != null) {
+            dirtyTypes = Collections.singletonList(cacheType);
+        }
+        if (dirtyTypes == null || dirtyTypes.isEmpty()) {
+            return;
+        }
+        Set<Requirement> requirements = requirementCache.keySet();
+        List<Requirement> toRemove = new ArrayList<>();
+
+        for (Requirement requirement : requirements) {
+            for (Class<? extends Requirement> dirtyType : dirtyTypes) {
+                if (dirtyType.isInstance(requirement)) {
+                    toRemove.add(requirement);
+                }
+            }
+        }
+        toRemove.forEach(requirement -> requirementCache.remove(requirement));
+    }
+
+    public static void registerDirtyTypes() {
+        //Register all Logic requirements to Requirement.class so that they always get invalidated when things become invalid
+        registerRequirementType(NOTRequirement.class, ANDRequirement.class, NANDRequirement.class, ORRequirement.class, NORRequirement.class,
+                XORRequirement.class, XNORRequirement.class);
+    }
+
+    //A method to allow adding of requirements that should always be invalidated if other requirements get invalidated
+    public static void registerRequirementType(Class<? extends Requirement>... requirementClasses) {
+        dirtyCacheTypes.addAll(Arrays.asList(requirementClasses));
+    }
+
+    public static void invalidateCache(EntityPlayer player, Class<? extends Requirement> cacheType) {
+        if (player != null) {
+            invalidateCache(player.getUniqueID(), cacheType);
+        }
+    }
+
+    public static void invalidateCache(UUID uuid, Class<? extends Requirement> cacheType) {
+        RequirementCache requirementCache = cacheMap.get(uuid);
+        if (requirementCache != null) {
+            requirementCache.invalidateCache(cacheType);
+        }
+    }
+
+    public static boolean requirementAchieved(EntityPlayer player, Requirement requirement) {
+        if (player != null) {
+            return requirementAchieved(player.getUniqueID(), requirement);
+        }
+        return false;
+    }
+
+    public static boolean requirementAchieved(UUID uuid, Requirement requirement) {
+        RequirementCache requirementCache = cacheMap.get(uuid);
+        if (requirementCache != null) {
+            return requirementCache.requirementAchieved(requirement);
+        }
+        return false;
+    }
+
+    //TODO add the listeners that invalidate the caches for the types we have
+    @SubscribeEvent
+    public static void onLevelChange(LevelUpEvent.Post event) {
+        //Just invalidate all skills because it is easier than checking each requirement they have to see if the skill matches
+        invalidateCache(event.getEntityPlayer().getUniqueID(), SkillRequirement.class);
+    }
+
+    @SubscribeEvent
+    public static void onUnlockableLocked(LockUnlockableEvent.Post event) {
+        invalidateCache(event.getEntityPlayer().getUniqueID(), TraitRequirement.class);
+    }
+
+    @SubscribeEvent
+    public static void onUnlockableUnlocked(UnlockUnlockableEvent.Post event) {
+        invalidateCache(event.getEntityPlayer().getUniqueID(), TraitRequirement.class);
+    }
+
+    @SubscribeEvent
+    public static void onAdvancement(AdvancementEvent event) {
+        invalidateCache(event.getEntityPlayer().getUniqueID(), AdvancementRequirement.class);
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -35,18 +35,15 @@ public class RequirementCache {
         return achieved;
     }
 
-    public void invalidateCache(Class<? extends Requirement> cacheType) {
-        List<Class<? extends Requirement>> dirtyTypes = null;
-        if (dirtyCache) {
-            //Clear all types that are supposed to be invalidated each time
-            dirtyTypes = new ArrayList<>(dirtyCacheTypes);
-            if (cacheType != null) {
-                dirtyTypes.add(cacheType);
-            }
-        } else if (cacheType != null) {
-            dirtyTypes = Collections.singletonList(cacheType);
+    public void invalidateCache(Class<? extends Requirement>... cacheType) {
+        List<Class<? extends Requirement>> dirtyTypes = dirtyCache ? new ArrayList<>(dirtyCacheTypes) : new ArrayList<>();
+        //Clear all types that are supposed to be invalidated each time if dirtyCache is true
+
+        if (cacheType != null) {
+            dirtyTypes.addAll(Arrays.asList(cacheType));
         }
-        if (dirtyTypes == null || dirtyTypes.isEmpty()) {
+
+        if (dirtyTypes.isEmpty()) {
             return;
         }
         Set<Requirement> requirements = requirementCache.keySet();
@@ -73,16 +70,16 @@ public class RequirementCache {
         dirtyCacheTypes.addAll(Arrays.asList(requirementClasses));
     }
 
-    public static void invalidateCache(EntityPlayer player, Class<? extends Requirement> cacheType) {
+    public static void invalidateCache(EntityPlayer player, Class<? extends Requirement>... cacheTypes) {
         if (player != null) {
-            invalidateCache(player.getUniqueID(), cacheType);
+            invalidateCache(player.getUniqueID(), cacheTypes);
         }
     }
 
-    public static void invalidateCache(UUID uuid, Class<? extends Requirement> cacheType) {
+    public static void invalidateCache(UUID uuid, Class<? extends Requirement>... cacheTypes) {
         RequirementCache requirementCache = cacheMap.get(uuid);
         if (requirementCache != null) {
-            requirementCache.invalidateCache(cacheType);
+            requirementCache.invalidateCache(cacheTypes);
         }
     }
 

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -18,7 +18,7 @@ public class RequirementCache {
     private static Set<Class<? extends Requirement>> dirtyCacheTypes = new HashSet<>();
     private static Map<UUID, RequirementCache> cacheMap = new HashMap<>();
 
-    //TODO: Check if Requirement needs to have updated equals and hashCode methods
+    //TODO: Requirement needs to have updated equals and hashCode methods
     private Map<Class<? extends Requirement>, Map<Requirement, Boolean>> requirementCache = new HashMap<>();
     private Set<Class<? extends Requirement>> recentlyInvalidated = new HashSet<>();
     private EntityPlayer player;

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -29,7 +29,6 @@ public class RequirementCache {
         cacheMap.put(player.getUniqueID(), this);
     }
 
-    //TODO: Implement the tooltip changes in CompatSkills of caching the format because it is the same for all requirements and then just inserting the color
     public boolean requirementAchieved(Requirement requirement) {
         if (requirement == null) {
             return false;

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -18,7 +18,8 @@ public class RequirementCache {
     private static Set<Class<? extends Requirement>> dirtyCacheTypes = new HashSet<>();
     private static Map<UUID, RequirementCache> cacheMap = new HashMap<>();
 
-    //TODO: Should it be requirement -> player/boolean so that it does not need to keep track of multiple requirements? They really are pointers so it should not matter
+    //TODO: Cache as Map<RequirementType, Map<Requirement, Boolean>> So that it is slightly more efficient for clearing out during invalidation
+    //TODO Cont: Will be a decent boost for performance if lots of items are checked in JEI for example with different requirements
     private Map<Requirement, Boolean> requirementCache = new HashMap<>();
     private Set<Class<? extends Requirement>> recentlyInvalidated = new HashSet<>();
     private EntityPlayer player;

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -18,7 +18,6 @@ public class RequirementCache {
     private static Set<Class<? extends Requirement>> dirtyCacheTypes = new HashSet<>();
     private static Map<UUID, RequirementCache> cacheMap = new HashMap<>();
 
-    //TODO: Requirement needs to have updated equals and hashCode methods
     private Map<Class<? extends Requirement>, Map<Requirement, Boolean>> requirementCache = new HashMap<>();
     private Set<Class<? extends Requirement>> recentlyInvalidated = new HashSet<>();
     private EntityPlayer player;

--- a/src/main/java/codersafterdark/reskillable/api/requirement/SkillRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/SkillRequirement.java
@@ -24,7 +24,7 @@ public class SkillRequirement extends Requirement {
     @Override
     public String getToolTip(PlayerData data) {
         return TextFormatting.GRAY + " - " + new TextComponentTranslation("skillable.misc.skillFormat", TextFormatting.DARK_AQUA, skill.getName(),
-                data == null || !achievedByPlayer(data.playerWR.get()) ? TextFormatting.RED : TextFormatting.GREEN, level).getUnformattedComponentText();
+                data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN, level).getUnformattedComponentText();
     }
 
     public Skill getSkill() {

--- a/src/main/java/codersafterdark/reskillable/api/requirement/SkillRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/SkillRequirement.java
@@ -6,6 +6,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
+import java.util.Objects;
+
 public class SkillRequirement extends Requirement {
     private final Skill skill;
     private final int level;
@@ -34,15 +36,15 @@ public class SkillRequirement extends Requirement {
     public RequirementComparision matches(Requirement other) {
         if (other instanceof SkillRequirement) {
             SkillRequirement skillRequirement = (SkillRequirement) other;
-            if (getSkill() == null || skillRequirement.getSkill() == null) {
+            if (skill == null || skillRequirement.skill == null) {
                 //If they are both invalid don't bother checking the level.
                 return RequirementComparision.NOT_EQUAL;
             }
-            if (getSkill().getKey().equals(skillRequirement.getSkill().getKey())) {
-                if (getLevel() == skillRequirement.getLevel()) {
+            if (skill.getKey().equals(skillRequirement.skill.getKey())) {
+                if (level == skillRequirement.level) {
                     return RequirementComparision.EQUAL_TO;
                 }
-                return getLevel() > skillRequirement.getLevel() ? RequirementComparision.GREATER_THAN : RequirementComparision.LESS_THAN;
+                return level > skillRequirement.level ? RequirementComparision.GREATER_THAN : RequirementComparision.LESS_THAN;
             }
         }
         return RequirementComparision.NOT_EQUAL;
@@ -50,6 +52,23 @@ public class SkillRequirement extends Requirement {
 
     @Override
     public boolean isEnabled() {
-        return getSkill() != null && getSkill().isEnabled();
+        return skill != null && skill.isEnabled();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof SkillRequirement) {
+            SkillRequirement sReq = (SkillRequirement) o;
+            return skill.equals(sReq.skill) && level == sReq.level;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(skill, level);
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/SkillRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/SkillRequirement.java
@@ -1,6 +1,5 @@
 package codersafterdark.reskillable.api.requirement;
 
-import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.skill.Skill;
 import net.minecraft.entity.player.EntityPlayer;
@@ -14,17 +13,13 @@ public class SkillRequirement extends Requirement {
     public SkillRequirement(Skill skill, int level) {
         this.skill = skill;
         this.level = level;
+        this.tooltip = TextFormatting.GRAY + " - " + new TextComponentTranslation("skillable.misc.skillFormat", TextFormatting.DARK_AQUA, skill.getName(),
+                "%s", level).getUnformattedComponentText();
     }
 
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayer) {
         return PlayerDataHandler.get(entityPlayer).getSkillInfo(skill).getLevel() >= level;
-    }
-
-    @Override
-    public String getToolTip(PlayerData data) {
-        return TextFormatting.GRAY + " - " + new TextComponentTranslation("skillable.misc.skillFormat", TextFormatting.DARK_AQUA, skill.getName(),
-                data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN, level).getUnformattedComponentText();
     }
 
     public Skill getSkill() {

--- a/src/main/java/codersafterdark/reskillable/api/requirement/TraitRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/TraitRequirement.java
@@ -32,7 +32,7 @@ public class TraitRequirement extends Requirement {
         String name = "";
 
         if (unlockable != null) {
-            if (data == null || !data.getSkillInfo(unlockable.getParentSkill()).isUnlocked(unlockable)) {
+            if (data == null || !data.requirementAchieved(this)) {
                 color = TextFormatting.RED;
             }
             name = unlockable.getName();

--- a/src/main/java/codersafterdark/reskillable/api/requirement/TraitRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/TraitRequirement.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
+import java.util.Objects;
+
 public class TraitRequirement extends Requirement {
     private Unlockable unlockable;
 
@@ -31,12 +33,22 @@ public class TraitRequirement extends Requirement {
 
     @Override
     public RequirementComparision matches(Requirement other) {
-        return other instanceof TraitRequirement ? getUnlockable().getKey().equals(((TraitRequirement) other).getUnlockable().getKey()) ?
+        return other instanceof TraitRequirement ? unlockable.getKey().equals(((TraitRequirement) other).unlockable.getKey()) ?
                 RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL : RequirementComparision.NOT_EQUAL;
     }
 
     @Override
     public boolean isEnabled() {
-        return getUnlockable() != null && getUnlockable().isEnabled();
+        return unlockable != null && unlockable.isEnabled();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof TraitRequirement && unlockable.equals(((TraitRequirement) o).unlockable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(unlockable);
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/TraitRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/TraitRequirement.java
@@ -1,43 +1,24 @@
 package codersafterdark.reskillable.api.requirement;
 
-import codersafterdark.reskillable.api.ReskillableRegistries;
-import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.skill.Skill;
 import codersafterdark.reskillable.api.unlockable.Unlockable;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TraitRequirement extends Requirement {
     private Unlockable unlockable;
 
-    public TraitRequirement(ResourceLocation traitName) {
-        this.unlockable = ReskillableRegistries.UNLOCKABLES.getValue(traitName);
+    public TraitRequirement(Unlockable unlockable) {
+        this.unlockable = unlockable;
+        this.tooltip =  TextFormatting.GRAY + " - " + TextFormatting.LIGHT_PURPLE + new TextComponentTranslation("skillable.misc.traitFormat", "%s",
+                this.unlockable.getName()).getUnformattedComponentText();
     }
 
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayer) {
         return PlayerDataHandler.get(entityPlayer).getSkillInfo(unlockable.getParentSkill()).isUnlocked(unlockable);
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public String getToolTip(PlayerData data) {
-        Unlockable unlockable = getUnlockable();
-        TextFormatting color = TextFormatting.GREEN;
-        String name = "";
-
-        if (unlockable != null) {
-            if (data == null || !data.requirementAchieved(this)) {
-                color = TextFormatting.RED;
-            }
-            name = unlockable.getName();
-        }
-        return TextFormatting.GRAY + " - " + TextFormatting.LIGHT_PURPLE + new TextComponentTranslation("skillable.misc.traitFormat", color, name).getUnformattedComponentText();
     }
 
     public Skill getSkill() {
@@ -50,14 +31,8 @@ public class TraitRequirement extends Requirement {
 
     @Override
     public RequirementComparision matches(Requirement other) {
-        if (other instanceof TraitRequirement) {
-            TraitRequirement traitRequirement = (TraitRequirement) other;
-            if (getUnlockable() == null) {
-                return traitRequirement.getUnlockable() == null ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
-            }
-            return traitRequirement.getUnlockable() != null && getUnlockable().getKey().equals(traitRequirement.getUnlockable().getKey()) ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
-        }
-        return RequirementComparision.NOT_EQUAL;
+        return other instanceof TraitRequirement ? getUnlockable().getKey().equals(((TraitRequirement) other).getUnlockable().getKey()) ?
+                RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL : RequirementComparision.NOT_EQUAL;
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/DoubleRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/DoubleRequirement.java
@@ -1,8 +1,8 @@
 package codersafterdark.reskillable.api.requirement.logic;
 
 import codersafterdark.reskillable.api.data.PlayerData;
-import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.requirement.Requirement;
+import codersafterdark.reskillable.api.requirement.RequirementCache;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.TextFormatting;
 
@@ -25,19 +25,16 @@ public abstract class DoubleRequirement extends Requirement {
     protected abstract String getFormat();
 
     protected boolean leftAchieved(EntityPlayer player) {
-        return player != null && PlayerDataHandler.get(player).requirementAchieved(left);
+        return player != null && RequirementCache.requirementAchieved(player, getLeft());
     }
 
     protected boolean rightAchieved(EntityPlayer player) {
-        return player != null && PlayerDataHandler.get(player).requirementAchieved(right);
+        return player != null && RequirementCache.requirementAchieved(player, getRight());
     }
 
     @Override
     public String getToolTip(PlayerData data) {
-        TextFormatting color = TextFormatting.GREEN;
-        if (data == null || !data.requirementAchieved(this)) {
-            color = TextFormatting.RED;
-        }
+        TextFormatting color = data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN;
         return TextFormatting.GRAY + " - " + getToolTipPart(data, getLeft()) + ' ' + color + getFormat() + ' ' + getToolTipPart(data, getRight());
     }
 

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/DoubleRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/DoubleRequirement.java
@@ -1,7 +1,9 @@
 package codersafterdark.reskillable.api.requirement.logic;
 
 import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.requirement.Requirement;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.TextFormatting;
 
 public abstract class DoubleRequirement extends Requirement {
@@ -22,10 +24,18 @@ public abstract class DoubleRequirement extends Requirement {
 
     protected abstract String getFormat();
 
+    protected boolean leftAchieved(EntityPlayer player) {
+        return player != null && PlayerDataHandler.get(player).requirementAchieved(left);
+    }
+
+    protected boolean rightAchieved(EntityPlayer player) {
+        return player != null && PlayerDataHandler.get(player).requirementAchieved(right);
+    }
+
     @Override
     public String getToolTip(PlayerData data) {
         TextFormatting color = TextFormatting.GREEN;
-        if (data == null || !achievedByPlayer(data.playerWR.get())) {
+        if (data == null || !data.requirementAchieved(this)) {
             color = TextFormatting.RED;
         }
         return TextFormatting.GRAY + " - " + getToolTipPart(data, getLeft()) + ' ' + color + getFormat() + ' ' + getToolTipPart(data, getRight());

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/DoubleRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/DoubleRequirement.java
@@ -51,4 +51,24 @@ public abstract class DoubleRequirement extends Requirement {
         }
         return tooltip;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof DoubleRequirement) {//The order of the logic requirements does not actually matter so might as well put it here
+            DoubleRequirement dreq = (DoubleRequirement) o;
+            return (getRight().equals(dreq.getRight()) && getLeft().equals(dreq.getLeft())) || (getRight().equals(dreq.getLeft()) && getLeft().equals(dreq.getRight()));
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        //Ensure there is no out of bounds errors AND that the hashcode is the same even if left and right got reversed
+        long leftHash = getLeft().hashCode();
+        long rightHash = getRight().hashCode();
+        return (int) ((leftHash + rightHash) / 2);
+    }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/FalseRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/FalseRequirement.java
@@ -26,4 +26,14 @@ public class FalseRequirement extends Requirement {
     public RequirementComparision matches(Requirement other) {
         return other instanceof FalseRequirement ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof FalseRequirement;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/FalseRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/FalseRequirement.java
@@ -8,6 +8,10 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
 public class FalseRequirement extends Requirement {
+    public FalseRequirement() {
+        this.tooltip = TextFormatting.RED + new TextComponentTranslation("skillable.misc.unobtainableFormat").getUnformattedComponentText();
+    }
+
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayerMP) {
         return false;
@@ -15,7 +19,7 @@ public class FalseRequirement extends Requirement {
 
     @Override
     public String getToolTip(PlayerData data) {
-        return TextFormatting.RED + new TextComponentTranslation("skillable.misc.unobtainableFormat").getUnformattedComponentText();
+        return tooltip;
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/TrueRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/TrueRequirement.java
@@ -27,4 +27,14 @@ public class TrueRequirement extends Requirement {
     public RequirementComparision matches(Requirement other) {
         return other instanceof TrueRequirement ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof TrueRequirement;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/TrueRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/TrueRequirement.java
@@ -8,6 +8,10 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
 public class TrueRequirement extends Requirement {
+    public TrueRequirement() {
+        this.tooltip = TextFormatting.GREEN + new TextComponentTranslation("skillable.misc.unobtainableFormat").getUnformattedComponentText();
+    }
+
     @Override
     public boolean achievedByPlayer(EntityPlayer entityPlayerMP) {
         return true;
@@ -16,7 +20,7 @@ public class TrueRequirement extends Requirement {
     @Override
     public String getToolTip(PlayerData data) {
         //Should never be needed but probably should be set anyways
-        return TextFormatting.GREEN + new TextComponentTranslation("skillable.misc.unobtainableFormat").getUnformattedComponentText();
+        return tooltip;
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/ANDRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/ANDRequirement.java
@@ -13,7 +13,7 @@ public class ANDRequirement extends DoubleRequirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer player) {
-        return getLeft().achievedByPlayer(player) && getRight().achievedByPlayer(player);
+        return leftAchieved(player) && rightAchieved(player);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NANDRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NANDRequirement.java
@@ -13,7 +13,7 @@ public class NANDRequirement extends DoubleRequirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer player) {
-        return !getLeft().achievedByPlayer(player) || !getRight().achievedByPlayer(player);
+        return !leftAchieved(player) || !rightAchieved(player);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NORRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NORRequirement.java
@@ -13,7 +13,7 @@ public class NORRequirement extends DoubleRequirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer player) {
-        return !getLeft().achievedByPlayer(player) && !getRight().achievedByPlayer(player);
+        return !leftAchieved(player) && !rightAchieved(player);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NOTRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NOTRequirement.java
@@ -20,38 +20,44 @@ public class NOTRequirement extends Requirement {
 
     @Override
     public String getToolTip(PlayerData data) {
-        String parentToolTip = this.requirement.getToolTip(data);
-        if (parentToolTip == null) {
-            return "";
-        }
-        if (parentToolTip.startsWith(TextFormatting.GRAY + " - ")) {
-            parentToolTip = parentToolTip.replaceFirst(TextFormatting.GRAY + " - ", "");
-        }
-        char colorCode = '\u00a7';
-        String start = TextFormatting.GRAY + " - ";
-        if (parentToolTip.length() > 2 && parentToolTip.startsWith(Character.toString(colorCode))) {
-            start += parentToolTip.substring(0, 2);
-            parentToolTip = parentToolTip.substring(2);
-        }
-        start += '!';
-        StringBuilder tooltip = new StringBuilder(start);
-        char[] chars = parentToolTip.toCharArray();
-        char lastChar = '!';
-        char red = 'c';
-        char green = 'a';
-        for (char c : chars) {
-            if (lastChar == colorCode && (c == red || c == green)) {
-                if (c == red) {
-                    tooltip.append(green);
-                } else {
-                    tooltip.append(red);
-                }
-            } else {
-                tooltip.append(c);
+        try {
+            //Just use the opposite coloring for the parent tooltip. Allows for red and green coloring of requirement name
+            return String.format(this.requirement.internalToolTip(), data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN);
+        } catch (IllegalArgumentException e) {
+            //If it fails fall back to old method of inverting the colors
+            String parentToolTip = this.requirement.getToolTip(data);
+            if (parentToolTip == null) {
+                return "";
             }
-            lastChar = c;
+            if (parentToolTip.startsWith(TextFormatting.GRAY + " - ")) {
+                parentToolTip = parentToolTip.replaceFirst(TextFormatting.GRAY + " - ", "");
+            }
+            char colorCode = '\u00a7';
+            String start = TextFormatting.GRAY + " - ";
+            if (parentToolTip.length() > 2 && parentToolTip.startsWith(Character.toString(colorCode))) {
+                start += parentToolTip.substring(0, 2);
+                parentToolTip = parentToolTip.substring(2);
+            }
+            start += '!';
+            StringBuilder tooltip = new StringBuilder(start);
+            char[] chars = parentToolTip.toCharArray();
+            char lastChar = '!';
+            char red = 'c';
+            char green = 'a';
+            for (char c : chars) {
+                if (lastChar == colorCode && (c == red || c == green)) {
+                    if (c == red) {
+                        tooltip.append(green);
+                    } else {
+                        tooltip.append(red);
+                    }
+                } else {
+                    tooltip.append(c);
+                }
+                lastChar = c;
+            }
+            return tooltip.toString();
         }
-        return tooltip.toString();
     }
 
     public Requirement getRequirement() {

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NOTRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NOTRequirement.java
@@ -11,6 +11,16 @@ public class NOTRequirement extends Requirement {
 
     public NOTRequirement(Requirement requirement) {
         this.requirement = requirement;
+        String parentToolTip = this.requirement.internalToolTip();
+        if (parentToolTip.startsWith(TextFormatting.GRAY + " - ")) {
+            parentToolTip = parentToolTip.replaceFirst(TextFormatting.GRAY + " - ", "");
+        }
+        String start = TextFormatting.GRAY + " - ";
+        if (parentToolTip.length() > 2 && parentToolTip.startsWith("\u00a7")) {
+            start += parentToolTip.substring(0, 2);
+            parentToolTip = parentToolTip.substring(2);
+        }
+        this.tooltip = start + '!' + parentToolTip;
     }
 
     @Override
@@ -22,7 +32,7 @@ public class NOTRequirement extends Requirement {
     public String getToolTip(PlayerData data) {
         try {
             //Just use the opposite coloring for the parent tooltip. Allows for red and green coloring of requirement name
-            return String.format(this.requirement.internalToolTip(), data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN);
+            return String.format(internalToolTip(), data == null || !data.requirementAchieved(this) ? TextFormatting.RED : TextFormatting.GREEN);
         } catch (IllegalArgumentException e) {
             //If it fails fall back to old method of inverting the colors
             String parentToolTip = this.requirement.getToolTip(data);

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NOTRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/NOTRequirement.java
@@ -77,7 +77,7 @@ public class NOTRequirement extends Requirement {
     @Override
     public RequirementComparision matches(Requirement o) {
         if (o instanceof NOTRequirement) {
-            RequirementComparision match = getRequirement().matches(((NOTRequirement) o).getRequirement());
+            RequirementComparision match = requirement.matches(((NOTRequirement) o).requirement);
             switch (match) {
                 case GREATER_THAN:
                     return RequirementComparision.LESS_THAN;
@@ -88,5 +88,15 @@ public class NOTRequirement extends Requirement {
             }
         }
         return RequirementComparision.NOT_EQUAL;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof NOTRequirement && requirement.equals(((NOTRequirement) o).requirement);
+    }
+
+    @Override
+    public int hashCode() {
+        return requirement.hashCode();
     }
 }

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/ORRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/ORRequirement.java
@@ -13,7 +13,7 @@ public class ORRequirement extends DoubleRequirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer player) {
-        return getLeft().achievedByPlayer(player) || getRight().achievedByPlayer(player);
+        return leftAchieved(player) || rightAchieved(player);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/XNORRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/XNORRequirement.java
@@ -13,7 +13,7 @@ public class XNORRequirement extends DoubleRequirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer player) {
-        return getLeft().achievedByPlayer(player) == getRight().achievedByPlayer(player);
+        return leftAchieved(player) == rightAchieved(player);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/XORRequirement.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/logic/impl/XORRequirement.java
@@ -13,7 +13,7 @@ public class XORRequirement extends DoubleRequirement {
 
     @Override
     public boolean achievedByPlayer(EntityPlayer player) {
-        return getLeft().achievedByPlayer(player) != getRight().achievedByPlayer(player);
+        return leftAchieved(player) != rightAchieved(player);
     }
 
     @Override

--- a/src/main/java/codersafterdark/reskillable/base/CommonProxy.java
+++ b/src/main/java/codersafterdark/reskillable/base/CommonProxy.java
@@ -1,6 +1,7 @@
 package codersafterdark.reskillable.base;
 
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.network.PacketHandler;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
@@ -16,6 +17,7 @@ public class CommonProxy {
     public void preInit(FMLPreInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(PlayerDataHandler.EventHandler.class);
         MinecraftForge.EVENT_BUS.register(LevelLockHandler.class);
+        MinecraftForge.EVENT_BUS.register(RequirementCache.class);
         MinecraftForge.EVENT_BUS.register(ToolTipHandler.class);
         ConfigHandler.init(event.getSuggestedConfigurationFile());
         PacketHandler.preInit();
@@ -26,6 +28,7 @@ public class CommonProxy {
 
     public void postInit(FMLPostInitializationEvent event) {
         LevelLockHandler.setupLocks();
+        RequirementCache.registerDirtyTypes();
     }
 
     public void serverStarting(FMLServerStartingEvent event) {

--- a/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
@@ -4,21 +4,29 @@ import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.data.RequirementHolder;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ToolTipHandler {
     private static RequirementHolder lastLock = LevelLockHandler.EMPTY_LOCK;
+    private static List<String> toolTip = new ArrayList<>();
     private static ItemStack lastItem;
     private static boolean enabled;
 
     public static void resetLast() {
         lastItem = null;
         lastLock = LevelLockHandler.EMPTY_LOCK;
+        toolTip = new ArrayList<>();
     }
 
     @SubscribeEvent
@@ -32,8 +40,15 @@ public class ToolTipHandler {
         if (lastItem != current) {
             lastItem = current;
             lastLock = LevelLockHandler.getSkillLock(current);
+            lastLock.addRequirementsIgnoreShift(data, toolTip = new ArrayList<>());
         }
-        lastLock.addRequirementsToTooltip(data, event.getToolTip());
+        List<String> curTooltip = event.getToolTip();
+        if (!ConfigHandler.hideRequirements || GuiScreen.isShiftKeyDown()) {
+            curTooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLock").getUnformattedComponentText());
+            curTooltip.addAll(toolTip);
+        } else {
+            curTooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLockShift").getUnformattedComponentText());
+        }
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
@@ -43,11 +43,13 @@ public class ToolTipHandler {
             lastLock.addRequirementsIgnoreShift(data, toolTip = new ArrayList<>());
         }
         List<String> curTooltip = event.getToolTip();
-        if (!ConfigHandler.hideRequirements || GuiScreen.isShiftKeyDown()) {
-            curTooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLock").getUnformattedComponentText());
-            curTooltip.addAll(toolTip);
-        } else {
-            curTooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLockShift").getUnformattedComponentText());
+        if (!toolTip.isEmpty()) {
+            if (!ConfigHandler.hideRequirements || GuiScreen.isShiftKeyDown()) {
+                curTooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLock").getUnformattedComponentText());
+                curTooltip.addAll(toolTip);
+            } else {
+                curTooltip.add(TextFormatting.DARK_PURPLE + new TextComponentTranslation("skillable.misc.skillLockShift").getUnformattedComponentText());
+            }
         }
     }
 

--- a/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
@@ -28,11 +28,14 @@ public class ToolTipHandler {
             return;
         }
         ItemStack current = event.getItemStack();
+        PlayerData data = PlayerDataHandler.get(Minecraft.getMinecraft().player);
         if (lastItem != current) {
+            if (data != null) {
+                data.resetRequirementCache();
+            }
             lastItem = current;
             lastLock = LevelLockHandler.getSkillLock(current);
         }
-        PlayerData data = PlayerDataHandler.get(Minecraft.getMinecraft().player);
         lastLock.addRequirementsToTooltip(data, event.getToolTip());
     }
 

--- a/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
+++ b/src/main/java/codersafterdark/reskillable/base/ToolTipHandler.java
@@ -30,9 +30,6 @@ public class ToolTipHandler {
         ItemStack current = event.getItemStack();
         PlayerData data = PlayerDataHandler.get(Minecraft.getMinecraft().player);
         if (lastItem != current) {
-            if (data != null) {
-                data.resetRequirementCache();
-            }
             lastItem = current;
             lastLock = LevelLockHandler.getSkillLock(current);
         }

--- a/src/main/java/codersafterdark/reskillable/client/base/HUDHandler.java
+++ b/src/main/java/codersafterdark/reskillable/client/base/HUDHandler.java
@@ -107,9 +107,6 @@ public class HUDHandler {
 
             for (AdvancementRequirement advancementRequirement : advancementRequirements) {
                 Advancement adv = advancementRequirement.getAdvancement();
-                if (adv == null) {
-                    return;
-                }
 
                 mc.getTextureManager().bindTexture(new ResourceLocation("textures/gui/advancements/widgets.png"));
                 DisplayInfo display = adv.getDisplay();

--- a/src/main/java/codersafterdark/reskillable/client/base/HUDHandler.java
+++ b/src/main/java/codersafterdark/reskillable/client/base/HUDHandler.java
@@ -107,6 +107,9 @@ public class HUDHandler {
 
             for (AdvancementRequirement advancementRequirement : advancementRequirements) {
                 Advancement adv = advancementRequirement.getAdvancement();
+                if (adv == null) {
+                    continue;
+                }
 
                 mc.getTextureManager().bindTexture(new ResourceLocation("textures/gui/advancements/widgets.png"));
                 DisplayInfo display = adv.getDisplay();

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
     "modid": "reskillable",
     "name": "Reskillable",
     "description": "Reskillable is a continuation of Skillable by Vazkii. \nReskillable is a mod about leveling various skills up, using XP. \nLeveling skills up allow you to unlock traits and use more items. \nBy default, a lot of vanilla items are locked to require leveling your skills up. \nFor example, you're not allowed to use a Diamond Pickaxe until you reach level 16 Mining.",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "mcversion": "1.12.2",
     "url": "https://minecraft.curseforge.com/projects/reskillable",
     "authorList": ["Lanse505", "Buuz135", "jaredlll08", "SkySom"],


### PR DESCRIPTION
Allows Requirements to be cached and for parts of the cache to be invalidated. All Requirements now require proper cache invalidation handling OR to be added as always getting invalidated using `RequirementCache.registerRequirementType`

The main benefits of this pull request are that Logic Requirements (especially nested ones) and other complex Requirements (CompatSkills ItemRequirements for example) will not have to recalculate their values (or partial values) unless something has changed. Mainly used for the tooltips as those usually get shown just after checking if the requirement is met so we already know if it is achieved when calculating the colors.

I still need to do more testing before this can be merged. Once [WIP] is removed from the title this pull will be good to go.