### PR TITLE
Auto-unlock free unlockables

### DIFF
--- a/src/main/java/codersafterdark/reskillable/api/data/PlayerDataHandler.java
+++ b/src/main/java/codersafterdark/reskillable/api/data/PlayerDataHandler.java
@@ -1,5 +1,6 @@
 package codersafterdark.reskillable.api.data;
 
+import codersafterdark.reskillable.api.unlockable.AutoUnlocker;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.event.entity.living.EnderTeleportEvent;
@@ -91,6 +92,7 @@ public class PlayerDataHandler {
             if (data != null) {
                 data.sync();
             }
+            AutoUnlocker.recheck(event.player);
         }
 
         @SubscribeEvent

--- a/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
+++ b/src/main/java/codersafterdark/reskillable/api/requirement/RequirementCache.java
@@ -5,6 +5,7 @@ import codersafterdark.reskillable.api.event.LockUnlockableEvent;
 import codersafterdark.reskillable.api.event.UnlockUnlockableEvent;
 import codersafterdark.reskillable.api.requirement.logic.DoubleRequirement;
 import codersafterdark.reskillable.api.requirement.logic.impl.NOTRequirement;
+import codersafterdark.reskillable.api.unlockable.AutoUnlocker;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -74,6 +75,9 @@ public class RequirementCache {
         if (dirtyTypes.isEmpty()) {
             return;
         }
+
+        AutoUnlocker.recheck(player);//Hijacks this method so that it does not have to check on a timer and can instead only recheck on state change
+
         Set<Class<? extends Requirement>> requirements = requirementCache.keySet();
         List<Class<? extends Requirement>> toRemove = new ArrayList<>();
 

--- a/src/main/java/codersafterdark/reskillable/api/unlockable/AutoUnlocker.java
+++ b/src/main/java/codersafterdark/reskillable/api/unlockable/AutoUnlocker.java
@@ -4,6 +4,8 @@ import codersafterdark.reskillable.api.ReskillableRegistries;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.data.PlayerSkillInfo;
+import codersafterdark.reskillable.api.data.RequirementHolder;
+import codersafterdark.reskillable.base.LevelLockHandler;
 import net.minecraft.entity.player.EntityPlayer;
 
 import java.util.Collection;
@@ -46,9 +48,12 @@ public class AutoUnlocker {
         boolean anyUnlocked = false;
         for (Unlockable u : unlockables) {
             PlayerSkillInfo skillInfo = data.getSkillInfo(u.getParentSkill());
-            if (!skillInfo.isUnlocked(u) && data.matchStats(u.getRequirements())) {
-                skillInfo.unlock(u, player);
-                anyUnlocked = true;
+            if (!skillInfo.isUnlocked(u)) {
+                RequirementHolder holder = u.getRequirements();
+                if (holder.equals(LevelLockHandler.EMPTY_LOCK) || data.matchStats(holder)) {
+                    skillInfo.unlock(u, player);
+                    anyUnlocked = true;
+                }
             }
         }
         if (anyUnlocked) {

--- a/src/main/java/codersafterdark/reskillable/api/unlockable/AutoUnlocker.java
+++ b/src/main/java/codersafterdark/reskillable/api/unlockable/AutoUnlocker.java
@@ -1,0 +1,58 @@
+package codersafterdark.reskillable.api.unlockable;
+
+import codersafterdark.reskillable.api.ReskillableRegistries;
+import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.data.PlayerSkillInfo;
+import net.minecraft.entity.player.EntityPlayer;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AutoUnlocker {
+    private static Set<Unlockable> unlockables = new HashSet<>();
+
+    public static void setUnlockables() {
+        if (unlockables.isEmpty()) {
+            Collection<Unlockable> entries = ReskillableRegistries.UNLOCKABLES.getValuesCollection();
+            for (Unlockable u : entries) {
+                if (u.isEnabled() && u.getCost() == 0) {
+                    unlockables.add(u);
+                }
+            }
+        }
+    }
+
+    //Generic method that just rechecks all unlockables because it is a lot simpler than trying to gather the unlockable from the config
+    public static void recheckUnlockables() {
+        Collection<Unlockable> entries = ReskillableRegistries.UNLOCKABLES.getValuesCollection();
+        for (Unlockable u : entries) {
+            if (u.isEnabled() && u.getCost() == 0) {
+                unlockables.add(u);
+            } else {
+                unlockables.remove(u);
+            }
+        }
+        //TODO: This should really recheck all online players. Though I do not believe there is any real way to currently change cost while players are connected
+    }
+
+    public static void recheck(EntityPlayer player) {
+        PlayerData data = PlayerDataHandler.get(player);
+        if (data == null) {
+            return;
+        }
+
+        boolean anyUnlocked = false;
+        for (Unlockable u : unlockables) {
+            PlayerSkillInfo skillInfo = data.getSkillInfo(u.getParentSkill());
+            if (!skillInfo.isUnlocked(u) && data.matchStats(u.getRequirements())) {
+                skillInfo.unlock(u, player);
+                anyUnlocked = true;
+            }
+        }
+        if (anyUnlocked) {
+            data.saveAndSync();
+        }
+    }
+}

--- a/src/main/java/codersafterdark/reskillable/api/unlockable/UnlockableConfig.java
+++ b/src/main/java/codersafterdark/reskillable/api/unlockable/UnlockableConfig.java
@@ -15,6 +15,7 @@ public class UnlockableConfig {
 
     public void setCost(int cost) {
         this.cost = cost;
+        AutoUnlocker.recheckUnlockables();
     }
 
     public RequirementHolder getRequirementHolder() {

--- a/src/main/java/codersafterdark/reskillable/base/CommonProxy.java
+++ b/src/main/java/codersafterdark/reskillable/base/CommonProxy.java
@@ -2,6 +2,7 @@ package codersafterdark.reskillable.base;
 
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.requirement.RequirementCache;
+import codersafterdark.reskillable.api.unlockable.AutoUnlocker;
 import codersafterdark.reskillable.network.PacketHandler;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementProgress;
@@ -29,6 +30,7 @@ public class CommonProxy {
     public void postInit(FMLPostInitializationEvent event) {
         LevelLockHandler.setupLocks();
         RequirementCache.registerDirtyTypes();
+        AutoUnlocker.setUnlockables();
     }
 
     public void serverStarting(FMLServerStartingEvent event) {


### PR DESCRIPTION
If an Unlockable has a cost of 0, automatically unlock it for a player when they meet all the requirements. The main uses for this are with the GameStageUnlockables in CompatSkills as this way game stages can automatically be unlocked when specific requirements are met.

Hooking into a method from RequirementCaching allows this to only recheck players when their requirements states are no longer up to date, instead of having to check every `x` ticks/seconds.